### PR TITLE
Saving dummy binary file during build and retrieving it during game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ out
 .vs
 .vscode
 .DS_Store
+assets/shared
+assets/shared/pieces.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.1.0)
+cmake_minimum_required(VERSION 3.28)
 project(Blokus LANGUAGES CXX)
 
 # specify the C++ standard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 4.1.0)
 project(Blokus LANGUAGES CXX)
 
 # specify the C++ standard
 add_library(project_configs INTERFACE)
 target_compile_features(project_configs INTERFACE cxx_std_17)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ---------------- Dependencies ----------------
 include(FetchContent)
@@ -18,14 +20,29 @@ FetchContent_Declare(SFML
 FetchContent_MakeAvailable(SFML)
 
 # Fetch spdlog
-FetchContent_Declare(
-    spdlog
+FetchContent_Declare(spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG v1.14.1   # latest as of 2025
     GIT_SHALLOW ON
     EXCLUDE_FROM_ALL
     SYSTEM)
 FetchContent_MakeAvailable(spdlog)
+
+# Fetch flatbuffers
+FetchContent_Declare(flatbuffers
+  GIT_REPOSITORY https://github.com/google/flatbuffers.git
+  GIT_TAG        v23.5.26
+  GIT_SHALLOW    ON       
+  EXCLUDE_FROM_ALL            
+  SYSTEM                          
+)
+
+FetchContent_MakeAvailable(flatbuffers)
+
+# Manually create the alias if it doesn't exist
+if(NOT TARGET flatbuffers::flatbuffers)
+    add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
+endif()
 
 # All executables → bin/, all libraries → lib/
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -46,11 +63,34 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_INSTALL_RPATH "$ORIGIN")
 
 # ---- assets ----
-set(ASSETS_DIR "${CMAKE_SOURCE_DIR}/assets")
+set(ASSETS_PATH "${CMAKE_SOURCE_DIR}/assets")
+set(PIECES_PATH "${CMAKE_SOURCE_DIR}/assets/shared/pieces.bin")
+
+# Generate the headers for pre-game polyominoes
+
+list(APPEND CMAKE_MODULE_PATH ${flatbuffers_SOURCE_DIR}/CMake)
+include(BuildFlatBuffers)
+
+# Generate the C++ headers from the FlatBuffers schema
+flatbuffers_generate_headers(
+    TARGET PolyominoSchemaTarget
+    SCHEMAS "${CMAKE_SOURCE_DIR}/schema/polyomino.fbs"
+)
+
+target_include_directories(PolyominoSchemaTarget 
+    INTERFACE "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+# ---------------- Subdirectories ----------------
+# Add Shared Library
+add_subdirectory(src/shared)
+
+# Add Scripts Directory for pre-game generation
+add_subdirectory(scripts)
 
 # Add Source Directory (defines BlokusClient, BlokusTests)
 add_subdirectory(src/client)
-add_subdirectory(tests/client)
+add_subdirectory(tests)
 
 
 # ---- Testing ----

--- a/include/client/pregame.hpp
+++ b/include/client/pregame.hpp
@@ -1,0 +1,13 @@
+#ifndef PREGAME_HPP
+#define PREGAME_HPP
+
+#include <string>
+
+// Testing retrieving the saved data
+class PreGame
+{
+    public:
+        PreGame(const std::string& polyomino_path);
+};
+
+#endif // PREGAME_HPP

--- a/include/shared/polyomino_loader.hpp
+++ b/include/shared/polyomino_loader.hpp
@@ -1,0 +1,21 @@
+#ifndef POLYOMINO_LOADER_HPP
+#define POLYOMINO_LOADER_HPP
+
+#include "shared/polyomino_util.hpp"
+
+#include <string>
+#include <vector>
+
+namespace Blokus 
+{
+    // Saves the raw definitions into the FlatBuffer binary format
+    void save_to_binary(const std::string& filepath, const std::vector<PolyominoDefinition>& pieces);
+
+    // Reads the binary file and returns a buffer the game can use
+    // Using std::vector<char> ensures the memory stays alive
+    std::vector<char> load_binary_file(const std::string& filepath);
+
+    // Additional parsing functions for corners, edges, ids, etc. can be added here
+}
+
+#endif // POLYOMINO_LOADER_HPP

--- a/include/shared/polyomino_util.hpp
+++ b/include/shared/polyomino_util.hpp
@@ -1,0 +1,17 @@
+#ifndef POLYOMINO_UTIL_HPP
+#define POLYOMINO_UTIL_HPP
+
+#include <vector>
+#include <set>
+
+namespace Blokus
+{
+    struct PolyominoDefinition {
+        int id;
+    };
+
+    std::vector<PolyominoDefinition> generate_polyomino_metadata();
+
+}
+
+#endif // POLYOMINO_UTIL_HPP

--- a/schema/polyomino.fbs
+++ b/schema/polyomino.fbs
@@ -1,0 +1,14 @@
+namespace Blokus.Data;
+
+
+table PolyominoMetadata
+{
+    id: int;
+}
+
+table PieceLibrary
+{
+    pieces: [PolyominoMetadata];
+}
+
+root_type PieceLibrary;

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,0 +1,23 @@
+# All executables defined in the scripts/ directory 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/scripts)
+
+# Define the executable 
+add_executable(generate_polyominoes polyomino_generation.cpp)
+
+# Link the libraries
+target_link_libraries(generate_polyominoes PRIVATE 
+    BlokusSharedLib 
+)
+
+# Passing where to save binary as argument
+add_custom_command(
+    OUTPUT "${PIECES_PATH}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_SOURCE_DIR}/assets/shared"
+    COMMAND $<TARGET_FILE:generate_polyominoes> "${PIECES_PATH}"
+    DEPENDS generate_polyominoes "${CMAKE_SOURCE_DIR}/schema/polyomino.fbs"
+    COMMENT "Generating pieces.bin because source or schema changed..."
+    VERBATIM
+)
+
+# Create a target so you can actually trigger this recipe
+add_custom_target(generate_assets ALL DEPENDS "${PIECES_PATH}")

--- a/scripts/polyomino_generation.cpp
+++ b/scripts/polyomino_generation.cpp
@@ -1,0 +1,22 @@
+
+#include "polyomino_generated.h"
+
+#include "shared/polyomino_util.hpp"
+#include "shared/polyomino_loader.hpp"
+#include <iostream>
+
+int main(int argc, char** argv) 
+{
+    if (argc < 2) 
+    { 
+        std::cerr << "Usage: " << argv[0] << " <output_path>" << std::endl;
+        return 1;
+    }
+
+    std::vector<Blokus::PolyominoDefinition> raw_data = Blokus::generate_polyomino_metadata();
+    std::string output_path = argv[1];
+
+    Blokus::save_to_binary(output_path, raw_data);
+    
+    return 0;
+}

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Define library to be shared with tests
 add_library(BlokusClientLib STATIC 
 game.cpp 
-statistics_tracker.cpp)
+statistics_tracker.cpp
+pregame.cpp
+)
 
 # Link dependencies
 target_link_libraries(BlokusClientLib PUBLIC
@@ -9,6 +11,8 @@ target_link_libraries(BlokusClientLib PUBLIC
     SFML::Window
     SFML::System
     spdlog::spdlog
+    BlokusSharedLib
+    PolyominoSchemaTarget
     project_configs
 )
 
@@ -19,7 +23,8 @@ target_include_directories(BlokusClientLib PUBLIC
 
 # Define ASSETS_PATH
 target_compile_definitions(BlokusClientLib PRIVATE 
-    ASSETS_PATH=\"${ASSETS_DIR}\")
+    ASSETS_PATH=\"${ASSETS_PATH}\"
+)
 
 # Define client executable
 add_executable(BlokusClient main.cpp)
@@ -27,6 +32,11 @@ add_executable(BlokusClient main.cpp)
 # Link dependencies
 target_link_libraries(BlokusClient PRIVATE
     BlokusClientLib
+)
+
+# Define PIECES_PATH
+target_compile_definitions(BlokusClient PRIVATE 
+    PIECES_PATH=\"${PIECES_PATH}\"
 )
 
 # Assets copy (Portability)

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,8 +1,15 @@
 #include "game.hpp"
+#include "pregame.hpp"
+
+#include <iostream>
 
 
-int main(int argc, char* argv[])
+int main(int argc, char** argv)
 {
+    // Load pre-game data using where the pieces are stored
+    std::string piece_path = std::string(PIECES_PATH);
+    PreGame pregame(piece_path);
+    
     Game game;
     game.Run();
 

--- a/src/client/pregame.cpp
+++ b/src/client/pregame.cpp
@@ -1,0 +1,26 @@
+#include "pregame.hpp"
+
+#include "polyomino_generated.h"
+#include "shared/polyomino_loader.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+#include <vector>
+
+
+PreGame::PreGame(const std::string& polyomino_path)
+{
+    std::vector<char> buffer = Blokus::load_binary_file(polyomino_path);
+    auto piece_library = Blokus::Data::GetPieceLibrary(buffer.data());
+
+    // Access the data
+    auto pieces = piece_library->pieces(); 
+    std::cout << "Successfully loaded " << pieces->size() << " pieces!" << std::endl;
+
+    for (unsigned int i = 0; i < pieces->size(); ++i) 
+    {
+        auto piece = pieces->Get(i);
+        std::cout << "Piece Index: " << i << " | ID: " << piece->id() << std::endl;
+    }
+}

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+# Define library to be shared with tests
+add_library(BlokusSharedLib STATIC 
+    polyomino_util.cpp
+    polyomino_loader.cpp
+)
+
+# Link them so anyone using BlokusSharedLib also gets the headers
+target_link_libraries(BlokusSharedLib PUBLIC
+    PolyominoSchemaTarget
+    flatbuffers::flatbuffers
+    project_configs 
+)
+
+target_include_directories(BlokusSharedLib PUBLIC 
+    "${CMAKE_SOURCE_DIR}/include"
+    "${CMAKE_BINARY_DIR}/PolyominoSchemaTarget" 
+    "$<TARGET_PROPERTY:PolyominoSchemaTarget,BINARY_DIR>"
+)
+

--- a/src/shared/polyomino_loader.cpp
+++ b/src/shared/polyomino_loader.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <flatbuffers/flatbuffers.h>
+#include <filesystem>
 
 
 namespace Blokus

--- a/src/shared/polyomino_loader.cpp
+++ b/src/shared/polyomino_loader.cpp
@@ -1,0 +1,73 @@
+#include "shared/polyomino_loader.hpp"
+#include "polyomino_generated.h"
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <flatbuffers/flatbuffers.h>
+
+
+namespace Blokus
+ {
+
+    void save_to_binary(const std::string& filepath, 
+        const std::vector<PolyominoDefinition>& pieces) 
+    {
+        if (filepath.empty()) 
+        {
+            throw std::runtime_error("File path is empty");
+        }
+
+        if (pieces.empty()) 
+        {
+            throw std::runtime_error("No pieces to save");
+        }
+
+        flatbuffers::FlatBufferBuilder builder(1024);
+        std::vector<flatbuffers::Offset<Data::PolyominoMetadata>> piece_offsets;
+
+        for (const auto& piece : pieces) 
+        {
+            Blokus::Data::PolyominoMetadataBuilder piece_builder(builder);
+            piece_builder.add_id(piece.id);
+
+            auto piece_offset = piece_builder.Finish();
+            piece_offsets.push_back(piece_offset);
+        }
+
+        auto pieces_vec_offset = builder.CreateVector(piece_offsets);
+
+        Blokus::Data::PieceLibraryBuilder library_builder(builder);
+        library_builder.add_pieces(pieces_vec_offset);
+        auto root_offset = library_builder.Finish();
+
+        builder.Finish(root_offset);
+
+        std::ofstream outfile(filepath, std::ios::binary);
+        outfile.write(reinterpret_cast<const char*>(builder.GetBufferPointer()), builder.GetSize());
+        outfile.close();
+    }
+
+    std::vector<char> load_binary_file(const std::string& filepath) 
+    {
+       // Read the binary file into a buffer
+        std::ifstream infile(filepath, std::ios::binary);
+        if (!infile) 
+        {
+            throw std::runtime_error("Binary file not found");
+        }
+
+        // Read the file into a buffer
+        uintmax_t size = std::filesystem::file_size(filepath);
+
+        std::vector<char> buffer(size);
+        if (!infile.read(buffer.data(), size)) 
+        {
+            throw std::runtime_error("Failed to read data");
+        }
+
+        return buffer;
+    }
+}
+
+

--- a/src/shared/polyomino_util.cpp
+++ b/src/shared/polyomino_util.cpp
@@ -1,0 +1,18 @@
+#include <vector>
+#include "shared/polyomino_util.hpp"
+
+
+namespace Blokus
+{
+    std::vector<PolyominoDefinition> generate_polyomino_metadata()
+    {
+        std::vector<PolyominoDefinition> definitions;
+        // Dummy implementation for illustration
+        for (int i = 0; i < 10; ++i) {
+            PolyominoDefinition def;
+            def.id = i;
+            definitions.push_back(def);
+        }
+        return definitions;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Fetch GoogleTest if not already available
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.15.2 # latest as of 2025
+    GIT_SHALLOW ON
+    EXCLUDE_FROM_ALL
+    SYSTEM
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # For Windows compatibility
+FetchContent_MakeAvailable(googletest)
+
+# Make GoogleTest commands available to all subdirectories
+include(GoogleTest)
+
+# All executables defined in the tests/ directory 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/tests)
+
+# Route to the workers
+add_subdirectory(shared)
+add_subdirectory(client)
+
+

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -1,18 +1,6 @@
-# Fetch GoogleTest if not already available
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.15.2 # latest as of 2025
-    GIT_SHALLOW ON
-    SYSTEM
-)
-FetchContent_MakeAvailable(googletest)
-
 # Build the test executable
 add_executable(BlokusClientTests
     statistics_tracker_unittest.cc
-
     # add other test files here
 )
 
@@ -34,7 +22,6 @@ if(MSVC AND WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 # Discover and register tests automatically
-include(GoogleTest)
 gtest_discover_tests(BlokusClientTests
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Build the test executable
+add_executable(BlokusSharedTests
+    polyomino_loader_unittest.cc
+    # add other test files here
+)
+
+
+target_link_libraries(BlokusSharedTests
+    PRIVATE
+        BlokusSharedLib
+        PolyominoSchemaTarget
+        GTest::gtest_main
+        GTest::gmock_main
+)
+
+if(MSVC AND WIN32 AND BUILD_SHARED_LIBS)
+    add_custom_command(TARGET BlokusSharedTests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_RUNTIME_DLLS:BlokusSharedTests>
+        $<TARGET_FILE_DIR:BlokusSharedTests>
+    COMMAND_EXPAND_LISTS
+    )
+endif()
+
+# Discover and register tests automatically
+gtest_discover_tests(BlokusSharedTests)

--- a/tests/shared/polyomino_loader_unittest.cc
+++ b/tests/shared/polyomino_loader_unittest.cc
@@ -1,0 +1,102 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+using ::testing::ThrowsMessage;
+using ::testing::HasSubstr;
+
+#include "shared/polyomino_loader.hpp"
+#include "shared/polyomino_util.hpp"
+#include "polyomino_generated.h"
+
+#include <filesystem>
+#include <fstream>
+
+
+namespace
+{
+    std::vector<Blokus::PolyominoDefinition> create_test_definitions()
+    {
+        std::vector<Blokus::PolyominoDefinition> definitions;
+        for (int i = 0; i < 3; ++i) {
+            Blokus::PolyominoDefinition definition;
+            definition.id = i;
+            definitions.push_back(definition);
+        }
+        return definitions;
+    }
+    
+    TEST(RoundTripTest, ExistingFile)
+    {   
+        // File created
+        const std::string file_path = "test_pieces.bin";
+        auto definitions = create_test_definitions();
+        EXPECT_NO_THROW(Blokus::save_to_binary(file_path, definitions));
+        EXPECT_TRUE(std::filesystem::exists(file_path));
+
+        // Load file to buffer
+        std::vector<char> buffer;
+        EXPECT_NO_THROW({ 
+            buffer = Blokus::load_binary_file(file_path); 
+        });
+
+        auto piece_library = Blokus::Data::GetPieceLibrary(buffer.data());
+
+        // Access the data
+        auto pieces = piece_library->pieces(); 
+        EXPECT_EQ(pieces->size(), definitions.size());
+
+        for (unsigned int i = 0; i < pieces->size(); ++i) 
+        {
+            auto piece = pieces->Get(i);
+            EXPECT_EQ(piece->id(), definitions[i].id);
+        }
+        
+        std::filesystem::remove(file_path);
+    }
+
+    TEST(SaveToBinaryTest, EmptyFileName)
+    {  
+        // Empty filename created with no pieces
+        const std::string empty_path = "";
+        auto definitions = create_test_definitions();
+
+        EXPECT_THAT(
+            [&]() { 
+                using namespace Blokus;
+                save_to_binary(empty_path, definitions); 
+            }, 
+            ThrowsMessage<std::runtime_error>(HasSubstr("File path is empty"))
+        );
+    }
+
+    TEST(SaveToBinaryTest, NoPieces)
+    { 
+        // File created with no pieces
+        const std::string file_path = "test_empty.bin";
+
+        EXPECT_THAT(
+            [&]() { 
+                using namespace Blokus;
+                std::vector<PolyominoDefinition> empty_vec;
+                save_to_binary(file_path, empty_vec); 
+            }, 
+            ThrowsMessage<std::runtime_error>(HasSubstr("No pieces to save"))
+        );
+    }
+
+    TEST(LoadBinaryTest, EmptyFileName)
+    {  
+        // Empty filename created with no pieces
+        const std::string non_existing_path = "non_existing_file.bin";
+
+        EXPECT_THAT(
+            [&]() { 
+                using namespace Blokus;
+                load_binary_file(non_existing_path); 
+            }, 
+            ThrowsMessage<std::runtime_error>(HasSubstr("Binary file not found"))
+        );
+    } 
+
+    // Not testing read failure that hasn't been found 
+}


### PR DESCRIPTION
# Description

## Binary file creation and retrieval
I created `PIECES_PATH` in the root `CMakeLists.txt` and use it for binary file creation and retrieval. 

## Dummy binary file 
I saved ten pieces with ids 0 to 9 using `polyomino_generation.cpp`, and verified the retrieval using `./bin/BlokusClient`

## Dummy flatbuffers schema
I added `flatbuffers` using CMake and used it to save the dummy binary data.


# Testing
Go to the build directory
`cd build`

Configure 
`cmake ..`

Build
`cmake --build .`

I checked that `pieces.bin` is created in assets/shared after build, indicating `./bin/scripts/generate_polyominoes` ran.

Run client executable
`./bin/BlokusClient`

Previous game screen showed and terminal showed these messages, meaning that the saved binary file is successfully retrieved.
```
Successfully loaded 10 pieces!
Piece Index: 0 | ID: 0
Piece Index: 1 | ID: 1
Piece Index: 2 | ID: 2
Piece Index: 3 | ID: 3
Piece Index: 4 | ID: 4
Piece Index: 5 | ID: 5
Piece Index: 6 | ID: 6
Piece Index: 7 | ID: 7
Piece Index: 8 | ID: 8
Piece Index: 9 | ID: 9
[2026-01-15 16:59:43.371] [info] Frames / Second = 4020.22
Time / Update = 248us
[2026-01-15 16:59:44.373] [info] Frames / Second = 4646.91
Time / Update = 215us
```

Run client test
`./bin/tests/BlokusClientTests`

All tests passed. (same tests as before)

Run shared test
`./bin/tests/BlokusSharedTests`

All tests passed. 

# Progress
This commit closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PreGame step that loads and reports available polyomino pieces at startup.

* **Tests**
  * Added unit tests covering polyomino binary save/load and error conditions.

* **Chores**
  * Build/tooling: added FlatBuffers support, automated asset generation, and reorganized shared modules.
  * VCS: ignored generated/shared asset files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->