### PR TITLE
Adding Edges and Corners to Polyomino

### DIFF
--- a/include/shared/constants.hpp
+++ b/include/shared/constants.hpp
@@ -17,6 +17,10 @@ namespace Blokus
         sf::Vector2i{-1, 0}, sf::Vector2i{0, -1}
     };
 
+    inline constexpr std::array<sf::Vector2i, 4> kDiagonalOffsets = {
+        sf::Vector2i{1, 1}, sf::Vector2i{-1, 1},
+        sf::Vector2i{1, -1}, sf::Vector2i{-1, -1}
+    };
 
     struct Vector2iCompare 
     {
@@ -32,11 +36,10 @@ namespace Blokus
         }
     };
 
-    using Polyomino = std::set<sf::Vector2i, Vector2iCompare>;
-    
+    using Blocks = std::set<sf::Vector2i, Vector2iCompare>;
 
     struct PolyominoComparator {
-        bool operator()(const Polyomino& lhs, const Polyomino& rhs) const {
+        bool operator()(const Blocks& lhs, const Blocks& rhs) const {
             // Example: Sort by size first
             if (lhs.size() != rhs.size()) {
                 return lhs.size() < rhs.size();
@@ -50,6 +53,31 @@ namespace Blokus
             );
         }
     };
+
+    const static int kCanonicalCount = 21;
+    const static int kPolyominoCount = 91;
+    
+    struct Polyomino
+    {
+        Blocks blocks;
+
+        struct 
+        {
+            Blocks edges;
+            Blocks corners;
+
+        } sensors;
+
+        Polyomino(Blocks piece)
+            : blocks(std::move(piece))
+        {}
+
+        Polyomino()
+        {
+           blocks.insert({0, 0});
+        }
+    };
+    
 }
 
 #endif

--- a/include/shared/polyomino_util.hpp
+++ b/include/shared/polyomino_util.hpp
@@ -12,15 +12,13 @@
 
 namespace Blokus
 {
-    const static int kCanonicalCount = 21;
-    const static int kPolyominoCount = 91;
     // For storage in flatbuffer
     // IDs 0-20: canonical polyominoes
     // IDs 21-90: transformations (rotations and reflections)
     struct PolyominoDefinition
     {
         std::array<Polyomino, kPolyominoCount> polyomino_by_id;  // All polyominoes indexed by ID
-        std::map<Polyomino, int, PolyominoComparator> id_by_polyomino; // All IDs indexed by Polyomino
+        std::map<Blocks, int, PolyominoComparator> id_by_polyomino; // All IDs indexed by Polyomino
         std::array<int, kPolyominoCount> clockwise_rotated_ids;
         std::array<int, kPolyominoCount> horizontally_reflected_ids;
         std::array<int, kPolyominoCount> transformed_to_canonical;
@@ -44,31 +42,32 @@ namespace Blokus
 
         private:
             void RegisterUniquePolyominoes(
-                std::deque<Polyomino>& source_canonical_pieces,
-                 const Polyomino &parent);
+                std::deque<Blocks>& source_canonical_pieces,
+                 const Blocks &parent);
 
-            void SearchTransformation(const Polyomino& piece,
-                std::set<Polyomino, PolyominoComparator>& found_polyominoes,
-                std::map<Polyomino, Polyomino, PolyominoComparator> &rotated_polyomino,
-                std::map<Polyomino, Polyomino, PolyominoComparator> &reflected_polyomino) const;
+            void SearchTransformation(const Blocks& piece,
+                std::set<Blocks, PolyominoComparator>& found_polyominoes,
+                std::map<Blocks, Blocks, PolyominoComparator> &rotated_polyomino,
+                std::map<Blocks, Blocks, PolyominoComparator> &reflected_polyomino) const;
 
-            void Record(std::deque<Polyomino>& source_canonical_pieces,
-                std::set<Polyomino, PolyominoComparator> &found_polyominoes,
-                const std::map<Polyomino, Polyomino, PolyominoComparator>& reflected_polyomino,
-                const std::map<Polyomino, Polyomino, PolyominoComparator>& rotated_polyomino);
+            void Record(std::deque<Blocks>& source_canonical_pieces,
+                std::set<Blocks, PolyominoComparator> &found_polyominoes,
+                const std::map<Blocks, Blocks, PolyominoComparator>& reflected_polyomino,
+                const std::map<Blocks, Blocks, PolyominoComparator>& rotated_polyomino);
 
             void RecordTransformations(int id,
-                const std::map<Polyomino, Polyomino, PolyominoComparator>& reflected_polyomino,
-                const std::map<Polyomino, Polyomino, PolyominoComparator>& rotated_polyomino);
+                const std::map<Blocks, Blocks, PolyominoComparator>& reflected_polyomino,
+                const std::map<Blocks, Blocks, PolyominoComparator>& rotated_polyomino);
 
+            void AddSensors(int id);
                             
-            Polyomino Normalize(const Polyomino& piece) const;
+            Blocks Normalize(const Blocks& piece) const;
 
-            sf::Vector2i GetOrigin(const Polyomino& piece) const;   
+            sf::Vector2i GetOrigin(const Blocks& piece) const;   
 
-            Polyomino RotateClockwise(const Polyomino& piece) const;
+            Blocks RotateClockwise(const Blocks& piece) const;
 
-            Polyomino ReflectHorizontally(const Polyomino& piece) const;
+            Blocks ReflectHorizontally(const Blocks& piece) const;
 
             // Two pointers to record polyominos at two places
             int canonical_pointer_ = 1;

--- a/schema/polyomino.fbs
+++ b/schema/polyomino.fbs
@@ -12,6 +12,9 @@ table Polyomino
 {
   id: int32 (key);  // Unique identifier (0-90)
   coordinates: [Coordinate];
+
+  edges: [Coordinate];
+  corners: [Coordinate];
 }
 
 // A simple pair to act as a map entry

--- a/src/shared/polyomino_loader.cpp
+++ b/src/shared/polyomino_loader.cpp
@@ -28,21 +28,38 @@ void SaveToBinary(const std::string& filepath,
     for (int id = 0; id < kPolyominoCount; ++id)
     {
         const Polyomino& piece = data.polyomino_by_id[id];
+        const Blocks& blocks = piece.blocks;
         
-        if (piece.empty())
+        if (blocks.empty())
         {
             throw std::runtime_error("Empty piece");
         }
 
         std::vector<Blokus::Data::Coordinate> coords;
-        coords.reserve(piece.size());
-        for (const auto block : piece)
+        coords.reserve(blocks.size());
+        for (const auto block : blocks)
         {
             coords.push_back(Blokus::Data::Coordinate{block.x, block.y});
         }
+
+        std::vector<Blokus::Data::Coordinate> edges;
+        edges.reserve(piece.sensors.edges.size());
+        for (const auto block : piece.sensors.edges)
+        {
+            edges.push_back(Blokus::Data::Coordinate{block.x, block.y});
+        }
+
+        std::vector<Blokus::Data::Coordinate> corners;
+        corners.reserve(piece.sensors.corners.size());
+        for (const auto block : piece.sensors.corners)
+        {
+            corners.push_back(Blokus::Data::Coordinate{block.x, block.y});
+        }
         
         auto coords_offset = builder.CreateVectorOfStructs(coords);
-        auto piece_offset = Blokus::Data::CreatePolyomino(builder, id, coords_offset);
+        auto edges_offset = builder.CreateVectorOfStructs(edges);
+        auto corners_offset = builder.CreateVectorOfStructs(corners);
+        auto piece_offset = Blokus::Data::CreatePolyomino(builder, id, coords_offset, edges_offset, corners_offset);
         polyomino_offsets.push_back(piece_offset);
     }
 
@@ -138,10 +155,21 @@ PolyominoDefinition LoadPieceLibrary(const std::string& filepath)
                 Polyomino poly;
                 for (auto coord : *poly_table->coordinates()) 
                 {
-                    poly.insert(sf::Vector2i{coord->x(), coord->y()});
+                    poly.blocks.insert(sf::Vector2i{coord->x(), coord->y()});
                 }
+
+                for (auto coord : *poly_table->edges()) 
+                {
+                    poly.sensors.edges.insert(sf::Vector2i{coord->x(), coord->y()});
+                }
+
+                for (auto coord : *poly_table->corners()) 
+                {
+                    poly.sensors.corners.insert(sf::Vector2i{coord->x(), coord->y()});
+                }
+
                 data.polyomino_by_id[id] = poly;
-                data.id_by_polyomino[poly] = id; // Also populate the reverse map!
+                data.id_by_polyomino[poly.blocks] = id; // Also populate the reverse map!
             }
         }
     }

--- a/src/shared/polyomino_util.cpp
+++ b/src/shared/polyomino_util.cpp
@@ -13,15 +13,17 @@ namespace Blokus
 PolyominoGenerator::PolyominoGenerator()
 {
     // BFS to generate all polyominoes up to kMaxBlocks
-    std::deque<Polyomino> source_canonical_pieces;
+    std::deque<Blocks> source_canonical_pieces;
     source_canonical_pieces.push_back({sf::Vector2i{0, 0}});
 
     // Store monomino into piece_library_
     piece_library_.id_by_polyomino[source_canonical_pieces.front()] = 0;
     piece_library_.polyomino_by_id[0] = source_canonical_pieces.front();
+    AddSensors(0);
+
     piece_library_.clockwise_rotated_ids[0] = 0;
     piece_library_.horizontally_reflected_ids[0] = 0;
-    for (int id = 0; id < 21; ++id)
+    for (int id = 0; id < kCanonicalCount; ++id)
     {
         piece_library_.transformed_to_canonical[id] = id;
     }
@@ -33,7 +35,7 @@ PolyominoGenerator::PolyominoGenerator()
         size_t piece_size_count = source_canonical_pieces.size();
         for (size_t i = 0; i < piece_size_count; ++i)
         {
-            Polyomino current_piece = std::move(source_canonical_pieces.front());
+            Blocks current_piece = std::move(source_canonical_pieces.front());
             source_canonical_pieces.pop_front();
 
             for (const sf::Vector2i block : current_piece)
@@ -64,10 +66,10 @@ PolyominoGenerator::PolyominoGenerator()
 } // PolyominoGenerator::PolyominoGenerator
 
 void PolyominoGenerator::RegisterUniquePolyominoes(
-    std::deque<Polyomino>& source_canonical_pieces, const Polyomino &piece)
+    std::deque<Blocks>& source_canonical_pieces, const Blocks &piece)
 {
     // Compute normalized form of the piece
-    Polyomino current = Normalize(piece);
+    Blocks current = Normalize(piece);
     if (piece_library_.id_by_polyomino.find(current) 
         != piece_library_.id_by_polyomino.end())
     {
@@ -75,9 +77,9 @@ void PolyominoGenerator::RegisterUniquePolyominoes(
     }
     
     // Compute rotated, reflected polyominoes
-    std::set<Polyomino, PolyominoComparator> found_polyominoes;
-    std::map<Polyomino, Polyomino, PolyominoComparator> rotated_polyomino;
-    std::map<Polyomino, Polyomino, PolyominoComparator> reflected_polyomino;
+    std::set<Blocks, PolyominoComparator> found_polyominoes;
+    std::map<Blocks, Blocks, PolyominoComparator> rotated_polyomino;
+    std::map<Blocks, Blocks, PolyominoComparator> reflected_polyomino;
     SearchTransformation(current, found_polyominoes, 
         rotated_polyomino, reflected_polyomino);
 
@@ -89,27 +91,27 @@ void PolyominoGenerator::RegisterUniquePolyominoes(
     Record(source_canonical_pieces, found_polyominoes, rotated_polyomino, reflected_polyomino);
 } // RegisterUniquePolyominoes
 
-void PolyominoGenerator::SearchTransformation(const Polyomino& piece,
-    std::set<Polyomino, PolyominoComparator>& found_polyominoes,
-    std::map<Polyomino, Polyomino, PolyominoComparator> &rotated_polyomino,
-    std::map<Polyomino, Polyomino, PolyominoComparator> &reflected_polyomino) const
+void PolyominoGenerator::SearchTransformation(const Blocks& piece,
+    std::set<Blocks, PolyominoComparator>& found_polyominoes,
+    std::map<Blocks, Blocks, PolyominoComparator> &rotated_polyomino,
+    std::map<Blocks, Blocks, PolyominoComparator> &reflected_polyomino) const
 {
-    std::vector<Polyomino> pieces {piece};
+    std::vector<Blocks> pieces {piece};
 
     while (!pieces.empty())
     {
-        Polyomino current = std::move(pieces.back());
+        Blocks current = std::move(pieces.back());
         found_polyominoes.insert(current);
         pieces.pop_back();
 
-        Polyomino rotated = RotateClockwise(current);
+        Blocks rotated = RotateClockwise(current);
         rotated_polyomino[current] = rotated;
         if (found_polyominoes.find(rotated) == found_polyominoes.end())
         {
             pieces.push_back(rotated);
         }
 
-        Polyomino reflected = ReflectHorizontally(current);
+        Blocks reflected = ReflectHorizontally(current);
         reflected_polyomino[current] = reflected;
         if (found_polyominoes.find(reflected) == found_polyominoes.end())
         {
@@ -118,26 +120,28 @@ void PolyominoGenerator::SearchTransformation(const Polyomino& piece,
     }
 }
 
-void PolyominoGenerator::Record(std::deque<Polyomino>& source_canonical_pieces,
-    std::set<Polyomino, PolyominoComparator> &found_polyominoes,
-    const std::map<Polyomino, Polyomino, PolyominoComparator>& rotated_polyomino,
-    const std::map<Polyomino, Polyomino, PolyominoComparator>& reflected_polyomino)
+void PolyominoGenerator::Record(std::deque<Blocks>& source_canonical_pieces,
+    std::set<Blocks, PolyominoComparator> &found_polyominoes,
+    const std::map<Blocks, Blocks, PolyominoComparator>& rotated_polyomino,
+    const std::map<Blocks, Blocks, PolyominoComparator>& reflected_polyomino)
 {
     auto start = found_polyominoes.begin();
 
     source_canonical_pieces.push_back(*start);
     piece_library_.polyomino_by_id[canonical_pointer_] = *start;
     piece_library_.id_by_polyomino[*start] = canonical_pointer_;
+    AddSensors(canonical_pointer_);
 
     found_polyominoes.erase(start);
 
     // Record transformed id
     int transformation_begin = transformation_pointer_;
-    for (const Polyomino piece : found_polyominoes) 
+    for (const Blocks piece : found_polyominoes) 
     {
         piece_library_.polyomino_by_id[transformation_pointer_] = piece;
         piece_library_.id_by_polyomino[piece] = transformation_pointer_;
         piece_library_.transformed_to_canonical[transformation_pointer_] = canonical_pointer_;
+        AddSensors(transformation_pointer_);
 
         ++transformation_pointer_;
     }
@@ -152,25 +156,23 @@ void PolyominoGenerator::Record(std::deque<Polyomino>& source_canonical_pieces,
 }
 
 void PolyominoGenerator::RecordTransformations(int id, 
-    const std::map<Polyomino, Polyomino, PolyominoComparator>& reflected_polyomino,
-    const std::map<Polyomino, Polyomino, PolyominoComparator>& rotated_polyomino)
+    const std::map<Blocks, Blocks, PolyominoComparator>& reflected_polyomino,
+    const std::map<Blocks, Blocks, PolyominoComparator>& rotated_polyomino)
 {
-    Polyomino current = piece_library_.polyomino_by_id[id];
+    Blocks current = piece_library_.polyomino_by_id[id].blocks;
     
-    Polyomino rotated = rotated_polyomino.at(current);
+    Blocks rotated = rotated_polyomino.at(current);
     int rotated_id = piece_library_.id_by_polyomino[rotated];
     piece_library_.clockwise_rotated_ids[id] = rotated_id;
 
-    Polyomino reflected = reflected_polyomino.at(current);
+    Blocks reflected = reflected_polyomino.at(current);
     int reflected_id = piece_library_.id_by_polyomino[reflected];
     piece_library_.horizontally_reflected_ids[id] = reflected_id;
 }
 
-
-
-Polyomino PolyominoGenerator::RotateClockwise(const Polyomino& piece) const
+Blocks PolyominoGenerator::RotateClockwise(const Blocks& piece) const
 {
-    Polyomino rotated_piece;
+    Blocks rotated_piece;
     for (const sf::Vector2i block : piece)
     { // rotate across the origin : (-y, x)
         rotated_piece.insert({ -block.y, block.x });
@@ -179,9 +181,9 @@ Polyomino PolyominoGenerator::RotateClockwise(const Polyomino& piece) const
     return Normalize(rotated_piece);
 }
 
-Polyomino PolyominoGenerator::ReflectHorizontally(const Polyomino& piece) const
+Blocks PolyominoGenerator::ReflectHorizontally(const Blocks& piece) const
 {
-    Polyomino reflected_piece;
+    Blocks reflected_piece;
     for (sf::Vector2i block : piece)
     { // reflect horizontally: (-x, y)
         reflected_piece.insert({ -block.x, block.y });
@@ -190,7 +192,7 @@ Polyomino PolyominoGenerator::ReflectHorizontally(const Polyomino& piece) const
     return Normalize(reflected_piece);
 }
 
-sf::Vector2i PolyominoGenerator::GetOrigin(const Polyomino& piece) const
+sf::Vector2i PolyominoGenerator::GetOrigin(const Blocks& piece) const
 { // Find minimum x and y (origin)
      sf::Vector2i origin = *piece.begin();
 
@@ -213,9 +215,9 @@ bool PolyominoGenerator::IsCanonical(int id) const
     return id >= 0 && id < kCanonicalCount;
 }
 
-Polyomino PolyominoGenerator::Normalize(const Polyomino& piece) const
+Blocks PolyominoGenerator::Normalize(const Blocks& piece) const
 { // Returns the normalized (canonical) form of the piece
-    Polyomino normalized;
+    Blocks normalized;
     sf::Vector2i origin = GetOrigin(piece);
     
     for (const sf::Vector2i block : piece)
@@ -224,5 +226,36 @@ Polyomino PolyominoGenerator::Normalize(const Polyomino& piece) const
     }
     
     return normalized;
+}
+
+void PolyominoGenerator::AddSensors(int id)
+{
+    Polyomino& piece = piece_library_.polyomino_by_id[id];
+    // Calculate edge blocks (neighbors of the polyomino that are not part of it)
+    for (const sf::Vector2i block : piece.blocks)
+    {
+        for (const auto dir : kCardinalOffsets)
+        {
+            sf::Vector2i neighbor = block + dir;
+            if (piece.blocks.find(neighbor) == piece.blocks.end())
+            {
+                piece.sensors.edges.insert(neighbor);
+            }
+        }
+    }
+
+    // Calculate corner blocks (diagonal neighbors of the polyomino that are not part of it or edge)
+    for (const sf::Vector2i block : piece.blocks)
+    {
+        for (const auto dir : kDiagonalOffsets)
+        {
+            sf::Vector2i neighbor = block + dir;
+            if (piece.blocks.find(neighbor) == piece.blocks.end() &&
+                piece.sensors.edges.find(neighbor) == piece.sensors.edges.end())
+            {
+                piece.sensors.corners.insert(neighbor);
+            }
+        }
+    }
 }
 } // namespace Blokus

--- a/tests/shared/polyomino_loader_unittest.cc
+++ b/tests/shared/polyomino_loader_unittest.cc
@@ -28,10 +28,15 @@ protected:
     PolyominoDefinition CreateMockDefinition() 
     {
         PolyominoDefinition def;
-        Polyomino monomino = { sf::Vector2i{0, 0} };
-        Polyomino domino = { sf::Vector2i{0, 0}, sf::Vector2i{0, 1} };
+        Blocks monomino = { sf::Vector2i{0, 0} };
 
-        def.polyomino_by_id[0] = monomino;
+        Polyomino piece (monomino);
+        piece.sensors.edges.insert({-1, 0});
+        piece.sensors.corners.insert({0, -1});
+
+        Blocks domino = { sf::Vector2i{0, 0}, sf::Vector2i{0, 1} };
+
+        def.polyomino_by_id[0] = piece;
         def.id_by_polyomino[monomino] = 0;
 
         for (int i = 1; i < kPolyominoCount ; ++i) 
@@ -84,14 +89,34 @@ TEST_F(BinaryIOTest, RoundTripDataIntegrity)
     PolyominoDefinition loaded = LoadPieceLibrary(valid_test_file);
 
     // Verify coordinates for a sample ID
-    EXPECT_EQ(loaded.polyomino_by_id[42], original.polyomino_by_id[42]);
+    EXPECT_EQ(loaded.polyomino_by_id[42].blocks, original.polyomino_by_id[42].blocks);
     
     // Verify rotation mapping (checking if the -1 fill logic was overwritten correctly)
     EXPECT_EQ(loaded.clockwise_rotated_ids[10], original.clockwise_rotated_ids[10]);
     
     // Verify reverse lookup map was populated
-    Polyomino monomino = { sf::Vector2i{0, 0} };
+    Blocks monomino = { sf::Vector2i{0, 0} };
     EXPECT_EQ(loaded.id_by_polyomino.at(monomino), 0); // Last ID assigned in mock
+}
+
+TEST_F(BinaryIOTest, SensorBinaryPersistence) {
+    PolyominoDefinition original = CreateMockDefinition();
+
+    // Save
+    ASSERT_NO_THROW(SaveToBinary(valid_test_file, original));
+    
+    // Load back
+    PolyominoDefinition loaded = LoadPieceLibrary(valid_test_file);
+    
+    // Check a sample piece (e.g., ID 10)
+    EXPECT_FALSE(loaded.polyomino_by_id[0].sensors.edges.empty());
+    EXPECT_EQ(loaded.polyomino_by_id[0].sensors.edges.size(), 1);
+    EXPECT_TRUE(loaded.polyomino_by_id[0].sensors.edges.find({-1, 0})
+                != loaded.polyomino_by_id[0].sensors.edges.end());
+    
+    EXPECT_EQ(loaded.polyomino_by_id[0].sensors.corners.size(), 1);
+    EXPECT_TRUE(loaded.polyomino_by_id[0].sensors.corners.find({0, -1})
+                != loaded.polyomino_by_id[0].sensors.corners.end());
 }
 
 } // namespace Blokus

--- a/tests/shared/polyomino_utils_unittest.cc
+++ b/tests/shared/polyomino_utils_unittest.cc
@@ -13,18 +13,16 @@ using ::testing::HasSubstr;
 #include <queue>
 
 
-
 namespace 
 {
     TEST(PolyominoGenerationTest, Integrity) {
         // 1. Generate or load the library
-        Blokus::PolyominoGenerator generator;
-        const auto& library = generator.GetData();
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
 
         // 2. Verify Bidirectional Mapping
         for (int i = 0; i < Blokus::kPolyominoCount; ++i) {
             // Get the shape associated with this ID
-            const Blokus::Polyomino& piece = library.polyomino_by_id[i];
+            const Blokus::Blocks& piece = library.polyomino_by_id[i].blocks;
 
             // Ensure the piece isn't empty (sanity check for the generator)
             ASSERT_FALSE(piece.empty()) << "Piece at ID " << i << " is empty!";
@@ -41,7 +39,7 @@ namespace
             EXPECT_EQ(mapped_id, i) 
                 << "Mapping mismatch! ID " << i << " points to a shape, "
                 << "but that shape points back to ID " << mapped_id;
-        }
+        }        
     }
 
     TEST(PolyominoGenerationTest, Rotation)
@@ -51,7 +49,6 @@ namespace
         // We track globally visited IDs to ensure every single ID 
         // is part of a valid rotation set.
         std::vector<bool> visited(Blokus::kPolyominoCount, false);
-
 
         for (int i = 0; i < Blokus::kPolyominoCount; ++i) {
             if (visited[i]) 
@@ -84,8 +81,8 @@ namespace
     }
 
     TEST(PolyominoGenerationTest, Reflection) {
-        Blokus::PolyominoGenerator generator;
-        const auto& library = generator.GetData();
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+
         
         // Globally track which IDs we've already verified
         std::vector<bool> visited(Blokus::kPolyominoCount, false);
@@ -111,8 +108,7 @@ namespace
     }
 
    TEST(PolyominoGenerationTest, CanonicalMappingIntegrity) {
-        Blokus::PolyominoGenerator generator;
-        const auto& library = generator.GetData();
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
 
         for (int i = 0; i < Blokus::kPolyominoCount; ++i) {
             int canonical_id = library.transformed_to_canonical[i];
@@ -134,12 +130,11 @@ namespace
 
     TEST(PolyominoGenerationTest, O_Tetromino) 
     {
-        Blokus::PolyominoGenerator generator;
-        auto &library = generator.GetData();
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
 
         // Create a 2x2 Square (O-Tetromino)
         // [(0,0), (1,0), (0,1), (1,1)]
-        Blokus::Polyomino square = {
+        Blokus::Blocks square = {
             {0, 0}, {1, 0},
             {0, 1}, {1, 1}
         };
@@ -160,12 +155,12 @@ namespace
 
     TEST(PolyominoGenerationTest, P_Pentomino) 
     {
-        Blokus::PolyominoGenerator generator;
-        const auto& library = generator.GetData();
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+
 
         // 1. Find the ID for the P-Pentomino
         // [(0,0), (1,0), (0,1), (1,1), (0,2)]
-        Blokus::Polyomino p_shape = {{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}};
+        Blokus::Blocks p_shape = {{0, 0}, {1, 0}, {0, 1}, {1, 1}, {0, 2}};
         ASSERT_TRUE(library.id_by_polyomino.count(p_shape)) << "P-Pentomino not found in library!";
         
         int start_id = library.id_by_polyomino.at(p_shape);
@@ -244,5 +239,134 @@ namespace
         {
             EXPECT_FALSE(generator.IsNormalized(i));
         }
+    }
+
+    TEST(PolyominoSensorTest, MonominoSensorCalculation) {
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+
+        // Create a 1x1 piece at (0,0)
+        Blokus::Blocks monomino = { {0, 0} };
+        
+        // Assume you have a function that generates sensors from blocks
+        Blokus::Polyomino p = library.polyomino_by_id[library.id_by_polyomino.at(monomino)];
+
+        // Verify Edges (Cardinal directions)
+        EXPECT_EQ(p.sensors.edges.size(), 4);
+        EXPECT_TRUE(std::find(p.sensors.edges.begin(), p.sensors.edges.end(), sf::Vector2i(1, 0)) != p.sensors.edges.end());
+        EXPECT_TRUE(std::find(p.sensors.edges.begin(), p.sensors.edges.end(), sf::Vector2i(0, 1)) != p.sensors.edges.end());
+
+        // Verify Corners (Diagonal directions)
+        EXPECT_EQ(p.sensors.corners.size(), 4);
+        EXPECT_TRUE(std::find(p.sensors.corners.begin(), p.sensors.corners.end(), sf::Vector2i(1, 1)) != p.sensors.corners.end());
+    }
+
+    TEST(PolyominoSensorTest, RotationConsistency) {
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+        // Use an L-shape (asymmetric)
+        Blokus::Blocks l_blocks = { {0,0}, {0,1}, {0,2}, {1,2} };
+        int id = library.id_by_polyomino.at(l_blocks);
+
+        int rotated_id = library.clockwise_rotated_ids[id];
+        Blokus::Polyomino rotated_object = library.polyomino_by_id.at(rotated_id);
+
+        // Manually calculated rotated edges
+        Blokus::Blocks expected_edges = { {-1, 0}, {-1, 1}, {0, -1}, {0, 2},
+                                {1, -1}, {1, 1}, {2, -1}, {2, 1}, {3, 0}};
+        EXPECT_EQ(rotated_object.sensors.edges, expected_edges);
+
+        // Manually calculated rotated corners
+        Blokus::Blocks expected_corners = { {-1, -1}, {-1, 2}, {1, 2}, 
+                                {3, -1}, {3, 1} };
+        EXPECT_EQ(rotated_object.sensors.corners, expected_corners);
+    }
+
+    TEST(PolyominoSensorTest, ReflectionConsistency) {
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+        // Use an L-shape (asymmetric)
+        Blokus::Blocks l_blocks = { {0,0}, {0,1}, {0,2}, {1,2} };
+        int id = library.id_by_polyomino.at(l_blocks);
+
+        int reflected_id = library.horizontally_reflected_ids[id];
+        Blokus::Polyomino reflected_object = library.polyomino_by_id.at(reflected_id);
+
+        // Manually calculated rotated edges
+        Blokus::Blocks expected_edges = { {-1, 2}, {0, 0}, {0, 1}, {0, 3},
+                                {1, -1}, {1, 3}, {2, 0}, {2, 1}, {2, 2}};
+        EXPECT_EQ(reflected_object.sensors.edges, expected_edges);
+
+        // Manually calculated rotated corners
+        Blokus::Blocks expected_corners = { {-1, 1}, {-1, 3}, {0, -1}, 
+                                {2, -1}, {2, 3} };
+        EXPECT_EQ(reflected_object.sensors.corners, expected_corners);
+    }
+
+    TEST(PolyominoSensorTest, SensorExclusion) {
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+
+        for (int i = 0; i < Blokus::kPolyominoCount; ++i) {
+            const auto& p = library.polyomino_by_id[i];
+            
+            // Ensure no Edge is inside the Blocks set
+            for (const auto& edge : p.sensors.edges) {
+                EXPECT_EQ(p.blocks.find(edge), p.blocks.end()) 
+                    << "ID " << i << " has an edge sensor overlapping a block at " << edge.x << "," << edge.y;
+            }
+
+            // Ensure no Corner is an Edge (Edges take precedence in Blokus rules)
+            for (const auto& corner : p.sensors.corners) {
+                auto it = std::find(p.blocks.begin(), p.blocks.end(), corner);
+                EXPECT_EQ(it, p.blocks.end());
+
+                it = std::find(p.sensors.edges.begin(), p.sensors.edges.end(), corner);
+                EXPECT_EQ(it, p.sensors.edges.end()) 
+                    << "ID " << i << " has a corner sensor overlapping an edge sensor at " << corner.x << "," << corner.y;
+            }
+        }
+    }
+
+    TEST(PolyominoSensorTest, FPentominoAdjacency) {
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+        // F-Pentomino: A very 'crowded' piece
+        Blokus::Blocks f_blocks = { {1,0}, {2,0}, {0,1}, {1,1}, {1,2} };
+        int id = library.id_by_polyomino.at(f_blocks);
+        Blokus::Polyomino f_polyomino = library.polyomino_by_id[id];
+
+        // Test: (1,1) is the center block. 
+        // Its neighbors are (1,0), (1,2), (0,1), (2,1).
+        // Three of those are BLOCKS. Therefore, they cannot be SENSORS.
+        for (const auto& block : f_polyomino.blocks) {
+            auto edge_it = std::find(f_polyomino.sensors.edges.begin(), f_polyomino.sensors.edges.end(), block);
+            auto corner_it = std::find(f_polyomino.sensors.corners.begin(), f_polyomino.sensors.corners.end(), block);
+            
+            EXPECT_EQ(edge_it, f_polyomino.sensors.edges.end()) << "Block at " << block.x << "," << block.y << " is also an edge!";
+            EXPECT_EQ(corner_it, f_polyomino.sensors.corners.end()) << "Block at " << block.x << "," << block.y << " is also a corner!";
+        }
+    }
+
+    TEST(PolyominoSensorTest, SensorBoundingBox) {
+        Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::GetData();
+        Blokus::Blocks monomino = { {0,0} };
+        Blokus::Polyomino p = library.polyomino_by_id[library.id_by_polyomino[monomino]];
+
+        int min_x = 0, max_x = 0, min_y = 0, max_y = 0;
+        
+        // Check all sensors (edges and corners)
+        auto check_bounds = [&](const Blokus::Blocks& sensors) {
+            for(const auto& v : sensors) {
+                min_x = std::min(min_x, v.x);
+                max_x = std::max(max_x, v.x);
+                min_y = std::min(min_y, v.y);
+                max_y = std::max(max_y, v.y);
+            }
+        };
+
+        check_bounds(p.sensors.edges);
+        check_bounds(p.sensors.corners);
+
+        // For a monomino at (0,0), sensors should span from (-1,-1) to (1,1)
+        EXPECT_EQ(min_x, -1);
+        EXPECT_EQ(max_x, 1);
+        EXPECT_EQ(min_y, -1);
+        EXPECT_EQ(max_y, 1);
     }
 }


### PR DESCRIPTION
## Progress
This PR closes #6 

## Description
- Renamed the previous Polyomino to Blocks
- Created Polyomino that includes its Blocks and Sensors
- Calculated Edges by iterating cardinally adjacent directions excluding Blocks
- Calculated Corners by iterating diagonally adjacent directions excluding Blocks and Edges
- Added logic to save sensors to binary and load the sensors

## Tests
- unit test for polyomino_utils.cpp and polyomino_loader.cpp
