### PR TITLE
Created piece node and mock resources for unit tests

### DIFF
--- a/include/client/Config.hpp
+++ b/include/client/Config.hpp
@@ -1,0 +1,19 @@
+#include <SFML/System/Vector2.hpp>
+#include "shared/Constants.hpp"
+
+
+namespace Config {
+    const unsigned int ScreenWidth = 1920;
+    const unsigned int ScreenHeight = 1080;
+    
+    const sf::Vector2f VirtualRes = { 
+        static_cast<float>(ScreenWidth), 
+        static_cast<float>(ScreenHeight) 
+    };
+
+    // --- Board Geometry (12x12) ---
+    const float GridSize = 35.f; 
+    const float TileSize = 512.f;
+
+    const float Padding = 100.f;
+}

--- a/include/client/Game.hpp
+++ b/include/client/Game.hpp
@@ -4,6 +4,7 @@
 #include "StatisticsTracker.hpp"
 #include "Resource/ResourceHolder.hpp"
 #include "Resource/ResourceIdentifiers.hpp"
+#include "Nodes/BlockNode.hpp"
 
 #include <SFML/System/Time.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
@@ -38,7 +39,8 @@ class Game
         static const sf::Time TimePerFrame;
 
         sf::RenderWindow mWindow;
-        sf::Sprite mTiles;
+
+        BlockNode mBlock;
 
         TextureHolder &mTextures;
         FontHolder &mFonts;

--- a/include/client/Game.hpp
+++ b/include/client/Game.hpp
@@ -4,7 +4,7 @@
 #include "StatisticsTracker.hpp"
 #include "Resource/ResourceHolder.hpp"
 #include "Resource/ResourceIdentifiers.hpp"
-#include "Nodes/BlockNode.hpp"
+#include "Nodes/PieceNode.hpp"
 
 #include <SFML/System/Time.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
@@ -40,7 +40,7 @@ class Game
 
         sf::RenderWindow mWindow;
 
-        BlockNode mBlock;
+        PieceNode mPiece;
 
         TextureHolder &mTextures;
         FontHolder &mFonts;

--- a/include/client/Nodes/BlockNode.hpp
+++ b/include/client/Nodes/BlockNode.hpp
@@ -1,0 +1,18 @@
+#ifndef BLOCKNODE_HPP
+#define BLOCKNODE_HPP
+
+#include "Nodes/SceneNode.hpp"
+#include <SFML/Graphics/Sprite.hpp>
+
+class BlockNode : public SceneNode {
+public:
+    explicit BlockNode(const sf::Texture& texture, const sf::IntRect& textureRect);
+
+private:
+    virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const override;
+    
+private:
+    sf::Sprite mBlock;
+};
+
+#endif

--- a/include/client/Nodes/BlockNode.hpp
+++ b/include/client/Nodes/BlockNode.hpp
@@ -8,6 +8,8 @@ class BlockNode : public SceneNode {
 public:
     explicit BlockNode(const sf::Texture& texture, const sf::IntRect& textureRect);
 
+    bool contains(sf::Vector2f worldPoint) const;
+
 private:
     virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const override;
     

--- a/include/client/Nodes/PieceNode.hpp
+++ b/include/client/Nodes/PieceNode.hpp
@@ -1,0 +1,33 @@
+#ifndef PIECENODE_HPP
+#define PIECENODE_HPP
+
+#include "Nodes/SceneNode.hpp"
+#include "shared/Team.hpp"
+#include "shared/PolyominoUtil.hpp"
+#include "shared/Constants.hpp"
+#include "Resource/ResourceHolder.hpp"
+#include "Resource/ResourceIdentifiers.hpp"
+#include "Nodes/SceneNode.hpp"
+
+
+class PieceNode : public SceneNode 
+{
+public:
+    explicit PieceNode(int pieceId, const Team team, TextureHolder& textures);
+
+    int getId() const;
+
+    void setId(int pieceId);
+
+    const Team getTeam() const;
+
+private:
+    void updateLayout();
+
+private:
+    int mCurrentId;
+    const Team mTeam;
+    TextureHolder& mTextures;
+};
+
+#endif

--- a/include/client/Nodes/PieceNode.hpp
+++ b/include/client/Nodes/PieceNode.hpp
@@ -10,6 +10,13 @@
 #include "Nodes/SceneNode.hpp"
 
 
+enum class PieceState
+{
+    Ready,
+    Moving,
+    Placed
+};
+
 class PieceNode : public SceneNode 
 {
 public:
@@ -21,12 +28,17 @@ public:
 
     const Team getTeam() const;
 
+    void setState(PieceState state);
+
+    PieceState getState() const;
+
 private:
     void updateLayout();
 
 private:
     int mCurrentId;
     const Team mTeam;
+    PieceState mState;
     TextureHolder& mTextures;
 };
 

--- a/include/client/Nodes/SceneNode.hpp
+++ b/include/client/Nodes/SceneNode.hpp
@@ -1,0 +1,56 @@
+#ifndef SCENENODE_HPP
+#define SCENENODE_HPP
+
+#include "SFML/System/Time.hpp"
+#include "SFML/Graphics/Transformable.hpp"
+#include "SFML/Graphics/Drawable.hpp"
+
+#include "SFML/Graphics/RenderStates.hpp"
+#include "SFML/Graphics/RenderTarget.hpp"
+
+#include <vector>
+#include <memory>
+
+
+class SceneNode : public sf::Transformable, public  sf::Drawable
+{
+    public:
+        typedef std::unique_ptr<SceneNode> Ptr;
+
+    public:
+        SceneNode();
+
+        void attachChild(Ptr child);
+
+        Ptr detachChild(const SceneNode& node);
+
+        void update(sf::Time dt);
+
+        sf::Vector2f getWorldPosition() const;
+
+        sf::Transform getWorldTransform() const;
+
+        // Helper for your Unit Tests
+        size_t getChildCount() const;
+        
+        SceneNode* getParent() const; 
+
+    private:
+        virtual void updateCurrent(sf::Time dt);
+        void updateChildren(sf::Time dt);
+
+        void draw(sf::RenderTarget& target, 
+            sf::RenderStates states) const;
+        virtual void drawCurrent(sf::RenderTarget& target,
+            sf::RenderStates states) const;
+        void drawChildren(sf::RenderTarget& target,
+            sf::RenderStates states) const;
+
+    private:
+        std::vector<Ptr> mChildren;
+        SceneNode* mParent;
+
+};
+
+
+#endif

--- a/include/client/Nodes/SceneNode.hpp
+++ b/include/client/Nodes/SceneNode.hpp
@@ -35,14 +35,19 @@ class SceneNode : public sf::Transformable, public  sf::Drawable
         
         SceneNode* getParent() const; 
 
+        void clearChildren();
+
     private:
         virtual void updateCurrent(sf::Time dt);
+        
         void updateChildren(sf::Time dt);
 
         void draw(sf::RenderTarget& target, 
             sf::RenderStates states) const;
+        
         virtual void drawCurrent(sf::RenderTarget& target,
             sf::RenderStates states) const;
+        
         void drawChildren(sf::RenderTarget& target,
             sf::RenderStates states) const;
 

--- a/include/client/Nodes/SceneNode.hpp
+++ b/include/client/Nodes/SceneNode.hpp
@@ -37,6 +37,8 @@ class SceneNode : public sf::Transformable, public  sf::Drawable
 
         void clearChildren();
 
+        virtual bool contains(sf::Vector2f worldPoint) const; 
+
     private:
         virtual void updateCurrent(sf::Time dt);
         

--- a/include/client/Resource/ResourceHolder.hpp
+++ b/include/client/Resource/ResourceHolder.hpp
@@ -12,22 +12,20 @@ template <typename Resource, typename Identifier>
 class ResourceHolder
 {
 	public:
-		void load(Identifier id, const std::string& filename);
+		virtual void load(Identifier id, const std::string& filename);
 
 		template <typename Parameter>
 		void load(Identifier id, const std::string& filename, const Parameter& secondParam);
 
-        void open(Identifier id, const std::string& filename);
-
 		Resource& get(Identifier id);
+		
 		const Resource& get(Identifier id) const;
 
-
-	private:
+	protected: // For unit testing
 		void insertResource(Identifier id, std::unique_ptr<Resource> resource);
 
 
-	private:
+	protected:
 		std::map<Identifier, std::unique_ptr<Resource>>	mResourceMap;
 };
 

--- a/include/client/Resource/ResourceHolder.inl
+++ b/include/client/Resource/ResourceHolder.inl
@@ -1,15 +1,24 @@
 #include "ResourceHolder.hpp"
+#include "SFML/Graphics/Font.hpp"
+
 
 template <typename Resource, typename Identifier>
-void ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string& filename)
-{
-	// Create and load resource
-	std::unique_ptr<Resource> resource(new Resource());
-	if (!resource->loadFromFile(filename))
-		throw std::runtime_error("ResourceHolder::load - Failed to load " + filename);
+void ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string& filename) {
+    auto resource = std::make_unique<Resource>();
 
-	// If loading successful, insert resource to map
-	insertResource(id, std::move(resource));
+    // Use if constexpr to handle SFML 3's naming differences
+    if constexpr (std::is_same_v<Resource, sf::Font>) 
+	{
+        if (!resource->openFromFile(filename))
+            throw std::runtime_error("ResourceHolder::load - Failed to open font " + filename);
+    } 
+	else  
+	{
+        if (!resource->loadFromFile(filename))
+            throw std::runtime_error("ResourceHolder::load - Failed to load resource " + filename);
+    }
+
+    insertResource(id, std::move(resource));
 }
 
 template <typename Resource, typename Identifier>
@@ -22,16 +31,6 @@ void ResourceHolder<Resource, Identifier>::load(Identifier id, const std::string
 		throw std::runtime_error("ResourceHolder::load - Failed to load " + filename);
 
 	// If loading successful, insert resource to map
-	insertResource(id, std::move(resource));
-}
-
-template <typename Resource, typename Identifier>
-void ResourceHolder<Resource, Identifier>::open(Identifier id, const std::string& filename) {
-	std::unique_ptr<Resource> resource(new Resource());
-	if (!resource->openFromFile(filename)) {
-		throw std::runtime_error("ResourceHolder::open - Failed to load " + filename);
-	}
-
 	insertResource(id, std::move(resource));
 }
 

--- a/include/shared/Constants.hpp
+++ b/include/shared/Constants.hpp
@@ -9,7 +9,7 @@
 namespace Blokus
 {
     inline constexpr int MaxBlocks = 5;
-    inline constexpr int BoardSize = 10;
+    inline constexpr int BoardSize = 12;
 
     inline constexpr std::array<sf::Vector2i, 4> CardinalOffsets = 
     {
@@ -55,8 +55,8 @@ namespace Blokus
         }
     };
 
-    const static int CanonicalCount = 21;
-    const static int PolyominoCount= 91;
+    const int CanonicalCount = 21;
+    const int PolyominoCount= 91;
     
     struct Polyomino
     {
@@ -78,8 +78,18 @@ namespace Blokus
         }
     };
 
-    const static float GridSize = 20.f; 
-    const static float TileSize = 512.f;
+    inline int getIndex(int x, int y) 
+    { 
+        return y * BoardSize + x; 
+    }
+
+    inline sf::Vector2i getCoord(int index) 
+    { 
+        return { index % BoardSize, index / BoardSize }; 
+    }
+
+    const int DeckSize = 18;
 }
+
 
 #endif

--- a/include/shared/Constants.hpp
+++ b/include/shared/Constants.hpp
@@ -77,6 +77,9 @@ namespace Blokus
         {
         }
     };
+
+    const static float GridSize = 20.f; 
+    const static float TileSize = 512.f;
 }
 
 #endif

--- a/include/shared/Team.hpp
+++ b/include/shared/Team.hpp
@@ -1,13 +1,16 @@
 #ifndef TEAM_HPP
 #define TEAM_HPP
 
-enum class Team : int
+enum Team : int
 {
-    None = 0,
+    None = -1,
     Red,
     Blue,
     Yellow,
-    Green
+    Green,
+    TeamCount
 };
+
+
 
 #endif

--- a/include/shared/Team.hpp
+++ b/include/shared/Team.hpp
@@ -1,0 +1,13 @@
+#ifndef TEAM_HPP
+#define TEAM_HPP
+
+enum class Team : int
+{
+    None = 0,
+    Red,
+    Blue,
+    Yellow,
+    Green
+};
+
+#endif

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Define library to be shared with tests
-add_library(BlokusClientLib STATIC 
-Game.cpp 
+add_library(BlokusClientLib STATIC
+Game.cpp
+Arena.cpp
 StatisticsTracker.cpp
-Resource/Path.cpp
-Nodes/SceneNode.cpp 
+Path.cpp
+Nodes/SceneNode.cpp
 Nodes/BlockNode.cpp
 Nodes/PieceNode.cpp
 )

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -4,6 +4,7 @@ Game.cpp
 StatisticsTracker.cpp
 Resource/Path.cpp
 Nodes/SceneNode.cpp 
+Nodes/BlockNode.cpp
 )
 
 # Link dependencies

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -5,6 +5,7 @@ StatisticsTracker.cpp
 Resource/Path.cpp
 Nodes/SceneNode.cpp 
 Nodes/BlockNode.cpp
+Nodes/PieceNode.cpp
 )
 
 # Link dependencies

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -2,7 +2,8 @@
 add_library(BlokusClientLib STATIC 
 Game.cpp 
 StatisticsTracker.cpp
-Resource/Path.cpp 
+Resource/Path.cpp
+Nodes/SceneNode.cpp 
 )
 
 # Link dependencies

--- a/src/client/Game.cpp
+++ b/src/client/Game.cpp
@@ -1,9 +1,19 @@
 #include "Game.hpp"
 #include "Resource/Path.hpp"
+#include "shared/Team.hpp"
 
 #include <stdexcept>
 #include <iostream>
 
+sf::IntRect getRect(Team team) {
+    switch(team) {
+        case Team::Blue:   return sf::IntRect({0, 0}, {512, 512});
+        case Team::Yellow: return sf::IntRect({512, 0}, {512, 512});
+        case Team::Red:    return sf::IntRect({0, 512}, {512, 512});
+        case Team::Green:  return sf::IntRect({512, 512}, {512, 512});
+        default:           return sf::IntRect({0, 0}, {0, 0});
+    }
+}
 
 const float Game::PlayerSpeed = 100.f;
 const sf::Time Game::TimePerFrame = sf::seconds(1.f / 60.f);
@@ -13,14 +23,14 @@ Game::Game(FontHolder& fonts, TextureHolder& textures)
     , mTextures(textures)
     , mFonts(fonts)
     , mStatistics()
-    , mTiles(textures.get(Textures::ID::Tiles))
+    , mBlock(textures.get(Textures::ID::Tiles), getRect(Team::Blue))
     , mIsMovingUp(false)
     , mIsMovingDown(false)
     , mIsMovingRight(false)
     , mIsMovingLeft(false)
 {
-    mTiles.setPosition({ 100.f, 100.f });
-    mTiles.setScale({ 1.f / 20.f, 1.f / 20.f });
+    mBlock.setPosition({ 100.f, 100.f });
+    mBlock.setScale({ 1.f / 20.f, 1.f / 20.f });
 }
 
 void Game::run()
@@ -81,15 +91,15 @@ void Game::update(sf::Time elapsedTime)
     if (mIsMovingRight)
         movement.x += PlayerSpeed;
 
-    mTiles.move(movement * elapsedTime.asSeconds());
+    mBlock.move(movement * elapsedTime.asSeconds());
 }
 
 void Game::render()
 {
     mWindow.clear();
-    mWindow.draw(mTiles);
-    std::cout << mTiles.getPosition().x << ", "
-    << mTiles.getPosition().y << "\n";
+    mWindow.draw(mBlock);
+    std::cout << mBlock.getPosition().x << ", "
+    << mBlock.getPosition().y << "\n";
     mWindow.display();
 }
 

--- a/src/client/Game.cpp
+++ b/src/client/Game.cpp
@@ -5,32 +5,24 @@
 #include <stdexcept>
 #include <iostream>
 
-sf::IntRect getRect(Team team) {
-    switch(team) {
-        case Team::Blue:   return sf::IntRect({0, 0}, {512, 512});
-        case Team::Yellow: return sf::IntRect({512, 0}, {512, 512});
-        case Team::Red:    return sf::IntRect({0, 512}, {512, 512});
-        case Team::Green:  return sf::IntRect({512, 512}, {512, 512});
-        default:           return sf::IntRect({0, 0}, {0, 0});
-    }
-}
 
 const float Game::PlayerSpeed = 100.f;
 const sf::Time Game::TimePerFrame = sf::seconds(1.f / 60.f);
+
 
 Game::Game(FontHolder& fonts, TextureHolder& textures)
     : mWindow(sf::VideoMode({ 640, 480 }), "Blokus", sf::Style::Close)
     , mTextures(textures)
     , mFonts(fonts)
     , mStatistics()
-    , mBlock(textures.get(Textures::ID::Tiles), getRect(Team::Blue))
+    , mPiece(88, Team::Green, textures)
     , mIsMovingUp(false)
     , mIsMovingDown(false)
     , mIsMovingRight(false)
     , mIsMovingLeft(false)
 {
-    mBlock.setPosition({ 100.f, 100.f });
-    mBlock.setScale({ 1.f / 20.f, 1.f / 20.f });
+
+    mPiece.setPosition({ 100.f, 100.f });
 }
 
 void Game::run()
@@ -91,15 +83,15 @@ void Game::update(sf::Time elapsedTime)
     if (mIsMovingRight)
         movement.x += PlayerSpeed;
 
-    mBlock.move(movement * elapsedTime.asSeconds());
+    mPiece.move(movement * elapsedTime.asSeconds());
 }
 
 void Game::render()
 {
     mWindow.clear();
-    mWindow.draw(mBlock);
-    std::cout << mBlock.getPosition().x << ", "
-    << mBlock.getPosition().y << "\n";
+    mWindow.draw(mPiece);
+    std::cout << mPiece.getPosition().x << ", "
+    << mPiece.getPosition().y << "\n";
     mWindow.display();
 }
 

--- a/src/client/Nodes/BlockNode.cpp
+++ b/src/client/Nodes/BlockNode.cpp
@@ -1,15 +1,30 @@
 #include "Nodes/BlockNode.hpp"
 #include "shared/Constants.hpp"
- 
+#include "Config.hpp"
+
 
 BlockNode::BlockNode(const sf::Texture& texture, const sf::IntRect& textureRect)
     : mBlock(texture, textureRect)
 {
-    float scaleFactor = Blokus::GridSize / Blokus::TileSize; 
+    float scaleFactor = Config::GridSize / Config::TileSize; 
     setScale({scaleFactor, scaleFactor});
 }
 
 void BlockNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const 
 {
     target.draw(mBlock, states);
+}
+
+bool BlockNode::contains(sf::Vector2f worldPoint) const 
+{
+    // 1. Get the sprite's bounds in the BlockNode's local space
+    sf::FloatRect localBounds = mBlock.getLocalBounds();
+
+    // 2. Transform that rect by the BlockNode's position/scale/rotation
+    // This moves the "hitbox" to the correct spot in the PieceNode
+    sf::FloatRect transformedBounds = getTransform().transformRect(localBounds);
+
+    // 3. Since the PieceNode is at {0,0} in your test, 
+    // transformedBounds is now in World Coordinates.
+    return transformedBounds.contains(worldPoint);
 }

--- a/src/client/Nodes/BlockNode.cpp
+++ b/src/client/Nodes/BlockNode.cpp
@@ -1,0 +1,11 @@
+#include "Nodes/BlockNode.hpp"
+
+BlockNode::BlockNode(const sf::Texture& texture, const sf::IntRect& textureRect)
+    : mBlock(texture, textureRect)
+{
+
+}
+
+void BlockNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const {
+    target.draw(mBlock, states);
+}

--- a/src/client/Nodes/BlockNode.cpp
+++ b/src/client/Nodes/BlockNode.cpp
@@ -1,11 +1,15 @@
 #include "Nodes/BlockNode.hpp"
+#include "shared/Constants.hpp"
+ 
 
 BlockNode::BlockNode(const sf::Texture& texture, const sf::IntRect& textureRect)
     : mBlock(texture, textureRect)
 {
-
+    float scaleFactor = Blokus::GridSize / Blokus::TileSize; 
+    setScale({scaleFactor, scaleFactor});
 }
 
-void BlockNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const {
+void BlockNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const 
+{
     target.draw(mBlock, states);
 }

--- a/src/client/Nodes/PieceNode.cpp
+++ b/src/client/Nodes/PieceNode.cpp
@@ -1,0 +1,69 @@
+#include "Nodes/PieceNode.hpp"
+#include "Nodes/BlockNode.hpp"
+
+#include "SFML/Graphics/Rect.hpp"
+
+#include <memory>
+#include <iostream>
+
+
+sf::IntRect getRect(Team team) {
+    int tileSize = static_cast<int>(Blokus::TileSize);
+    sf::Vector2i size = {tileSize, tileSize};
+
+    switch(team) 
+    {
+        case Team::Blue:   
+            return sf::IntRect({0, 0}, size);
+        case Team::Yellow: 
+            return sf::IntRect({tileSize, 0}, size);
+        case Team::Red:    
+            return sf::IntRect({0, tileSize}, size); 
+        case Team::Green:  
+            return sf::IntRect({tileSize, tileSize}, size);
+        default:           
+            return sf::IntRect({0, 0}, {0, 0});
+    }
+}
+
+PieceNode::PieceNode(int pieceId, const Team team, TextureHolder& textures)
+    : mCurrentId(pieceId)
+    , mTeam(team)
+    , mTextures(textures)
+{
+   updateLayout();
+}
+
+int PieceNode::getId() const
+{
+    return mCurrentId;
+}
+
+void PieceNode::setId(int pieceId)
+{
+    mCurrentId = pieceId;
+
+    updateLayout();
+}
+
+const Team PieceNode::getTeam() const
+{
+    return mTeam;
+}
+
+void PieceNode::updateLayout()
+{
+    clearChildren();
+
+    const auto &library = Blokus::PolyominoGenerator::getData();
+    const auto &coordinates = library.polyominoById.at(mCurrentId).blocks;
+
+    for (const auto& pos : coordinates) 
+    {
+        auto block = std::make_unique<BlockNode>(
+            mTextures.get(Textures::Tiles), getRect(mTeam));
+        
+        block->setPosition({pos.x * Blokus::GridSize, pos.y * Blokus::GridSize});
+        attachChild(std::move(block));
+    } 
+}

--- a/src/client/Nodes/PieceNode.cpp
+++ b/src/client/Nodes/PieceNode.cpp
@@ -1,5 +1,6 @@
 #include "Nodes/PieceNode.hpp"
 #include "Nodes/BlockNode.hpp"
+#include "Config.hpp"
 
 #include "SFML/Graphics/Rect.hpp"
 
@@ -8,7 +9,7 @@
 
 
 sf::IntRect getRect(Team team) {
-    int tileSize = static_cast<int>(Blokus::TileSize);
+    int tileSize = static_cast<int>(Config::TileSize);
     sf::Vector2i size = {tileSize, tileSize};
 
     switch(team) 
@@ -29,6 +30,7 @@ sf::IntRect getRect(Team team) {
 PieceNode::PieceNode(int pieceId, const Team team, TextureHolder& textures)
     : mCurrentId(pieceId)
     , mTeam(team)
+    , mState(PieceState::Ready)
     , mTextures(textures)
 {
    updateLayout();
@@ -63,7 +65,18 @@ void PieceNode::updateLayout()
         auto block = std::make_unique<BlockNode>(
             mTextures.get(Textures::Tiles), getRect(mTeam));
         
-        block->setPosition({pos.x * Blokus::GridSize, pos.y * Blokus::GridSize});
+        block->setPosition({pos.x * Config::GridSize, pos.y * Config::GridSize});
         attachChild(std::move(block));
     } 
 }
+
+void PieceNode::setState(PieceState state)
+{
+    mState = state;
+}
+
+PieceState PieceNode::getState() const
+{
+    return mState;
+}
+

--- a/src/client/Nodes/SceneNode.cpp
+++ b/src/client/Nodes/SceneNode.cpp
@@ -1,0 +1,99 @@
+#include "Nodes/SceneNode.hpp" 
+#include <algorithm>
+#include <cassert>
+
+
+SceneNode::SceneNode()
+    : mChildren()
+    , mParent(nullptr){}
+
+void SceneNode::attachChild(Ptr child)
+{
+    assert(child->mParent == nullptr);
+    child->mParent = this;
+    mChildren.emplace_back(std::move(child));
+}
+
+SceneNode::Ptr SceneNode::detachChild(const SceneNode& node)
+{
+    auto it = std::find_if(mChildren.begin(), mChildren.end(),
+        [&](const Ptr& child){
+            return child.get() == &node;
+        });
+    assert(it != mChildren.end());
+
+    auto ret = std::move(*it);
+    ret->mParent = nullptr;
+    mChildren.erase(it);
+
+    return ret;
+}
+
+void SceneNode::update(sf::Time dt)
+{
+    updateCurrent(dt);
+    updateChildren(dt);
+}
+
+void SceneNode::updateCurrent(sf::Time)
+{ // Handled by derived functions
+}
+
+void SceneNode::updateChildren(sf::Time dt)
+{
+    for(auto& child : mChildren)
+    {
+        child->update(dt);
+    }
+}
+
+void SceneNode::draw(sf::RenderTarget& target, 
+    sf::RenderStates states) const
+{
+    // Apply transformation of current node
+    states.transform *= getTransform();
+
+    drawCurrent(target, states);
+    drawChildren(target, states);
+}
+
+void SceneNode::drawCurrent(sf::RenderTarget& target,
+    sf::RenderStates states) const
+{ // Handled by derived functions
+}
+
+void SceneNode::drawChildren(sf::RenderTarget& target,
+    sf::RenderStates states) const
+{
+    for (const auto& child : mChildren)
+    {
+        child->draw(target, states);
+    }
+}
+
+sf::Vector2f SceneNode::getWorldPosition() const
+{
+    return getWorldTransform() * sf::Vector2f();
+}
+
+sf::Transform SceneNode::getWorldTransform() const
+{
+    sf::Transform transform = sf::Transform::Identity;
+
+    for (const SceneNode* node = this; node != nullptr; node = node->mParent)
+    {
+        transform = node->getTransform() * transform;
+    }
+
+    return transform;
+}
+
+size_t SceneNode::getChildCount() const 
+{ 
+    return mChildren.size(); 
+}
+        
+SceneNode* SceneNode::getParent() const 
+{ 
+    return mParent; 
+}

--- a/src/client/Nodes/SceneNode.cpp
+++ b/src/client/Nodes/SceneNode.cpp
@@ -97,3 +97,8 @@ SceneNode* SceneNode::getParent() const
 { 
     return mParent; 
 }
+
+void SceneNode::clearChildren()
+{
+    mChildren.clear();
+}

--- a/src/client/Nodes/SceneNode.cpp
+++ b/src/client/Nodes/SceneNode.cpp
@@ -102,3 +102,14 @@ void SceneNode::clearChildren()
 {
     mChildren.clear();
 }
+
+bool SceneNode::contains(sf::Vector2f worldPoint) const 
+{
+    for (const auto& child : mChildren) 
+    {
+        if (child->contains(worldPoint)) 
+            return true;
+    }
+
+    return false;
+}

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv)
 
     FontHolder fonts;
 	std::string fontFilename = getAssetPath("client/fonts/sansation.ttf");
-    fonts.open(Fonts::ID::Sansation, fontFilename);
+    fonts.load(Fonts::ID::Sansation, fontFilename);
 
     TextureHolder textures;
     std::string tileFilename = getAssetPath("client/textures/tiles.png");

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(BlokusClientTests
     StatisticsTrackerUnittest.cc
     Resource/ResourceHolderUnittest.cc
     Nodes/SceneNodeUnittest.cc
+    Nodes/PieceNodeUnittest.cc
     # add other test files here
 )
 
@@ -13,6 +14,13 @@ target_link_libraries(BlokusClientTests
         GTest::gtest_main
         spdlog::spdlog
 )
+
+# Include directories
+target_include_directories(BlokusClientTests PUBLIC 
+    ${CMAKE_CURRENT_SOURCE_DIR}                # Your client source code
+    ${CMAKE_CURRENT_SOURCE_DIR}/Mock # The Mock folder
+)
+
 
 if(MSVC AND WIN32 AND BUILD_SHARED_LIBS)
     add_custom_command(TARGET BlokusClientTests POST_BUILD

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(BlokusClientTests
     Resource/ResourceHolderUnittest.cc
     Nodes/SceneNodeUnittest.cc
     Nodes/PieceNodeUnittest.cc
+    # Nodes/BlockNodeUnittest.cc
+
     # add other test files here
 )
 

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(BlokusClientTests
     StatisticsTrackerUnittest.cc
     Resource/ResourceHolderUnittest.cc
+    Nodes/SceneNodeUnittest.cc
     # add other test files here
 )
 

--- a/tests/client/Mock/MockResource.hpp
+++ b/tests/client/Mock/MockResource.hpp
@@ -1,0 +1,47 @@
+#include <string>
+
+
+class MockResource
+{
+public:
+    MockResource() 
+    : mLoaded(false)
+    {}
+
+    bool loadFromFile(const std::string& filename)
+    {
+        // Simulate failure for specific filenames
+        if (filename == "invalid.txt")
+            return false;
+        mLoaded = true;
+        mFileName = filename;
+        return true;
+    }
+
+    template <typename Parameter>
+    bool loadFromFile(const std::string& filename, const Parameter& param)
+    {
+        // Simulate failure for specific filenames
+        if (filename == "invalid_param.txt")
+            return false;
+        mLoaded = true;
+        mFileName = filename;
+        mParameter = std::to_string(param);
+        return true;
+    }
+
+    bool isLoaded() const { return mLoaded; }
+    const std::string& getFileName() const { return mFileName; }
+    const std::string& getParameter() const { return mParameter; }
+
+private:
+    bool mLoaded;
+    std::string mFileName;
+    std::string mParameter;
+};
+
+ // Identifier enum for testing
+enum class ResourceID
+{
+    First = 0 
+};

--- a/tests/client/Mock/MockTextureHolder.hpp
+++ b/tests/client/Mock/MockTextureHolder.hpp
@@ -1,0 +1,16 @@
+#include "Resource/ResourceHolder.hpp"
+#include "Resource/ResourceIdentifiers.hpp"
+
+
+class MockTextureHolder : public ResourceHolder<sf::Texture, Textures::ID> 
+{
+public:
+    // Override load to do absolutely nothing
+    void load(Textures::ID id, const std::string& filename) override 
+    {
+        // We catch the call and stay silent. 
+        // Then we manually insert a dummy texture so 'get()' doesn't crash.
+        auto dummy = std::make_unique<sf::Texture>();
+        insertResource(id, std::move(dummy));
+    }
+};

--- a/tests/client/Nodes/PieceNodeUnittest.cc
+++ b/tests/client/Nodes/PieceNodeUnittest.cc
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 #include "Nodes/PieceNode.hpp" 
+#include "Config.hpp"
+
 #include "SFML/Graphics/Texture.hpp"
 #include <SFML/Window/Context.hpp>
 
@@ -79,4 +81,80 @@ TEST(PieceNodeTest, SetIdUpdatesBlocks)
     // Change to ID 1 (Suppose it has 2 blocks)
     piece.setId(1);
     EXPECT_EQ(piece.getChildCount(), 2); // The test now proves the layout updated!
+}
+
+TEST(PieceNodeTest, State) 
+{
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+
+    PieceNode piece(0, Team::Blue, testTextures);
+    EXPECT_EQ(piece.getState(), PieceState::Ready);
+
+    piece.setState(PieceState::Moving);
+    EXPECT_EQ(piece.getState(), PieceState::Moving);
+
+    piece.setState(PieceState::Placed);
+    EXPECT_EQ(piece.getState(), PieceState::Placed);
+}
+
+TEST(PieceNodeTest, MonominoContains) 
+{
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+
+    // ID 0 (1 block)    
+    auto monomino = std::make_unique<PieceNode>(0, Team::Blue, testTextures);
+    monomino->setPosition({0.f, 0.f});
+    EXPECT_EQ(monomino->getChildCount(), 1);
+    
+    EXPECT_FALSE(monomino->contains({-1, 0}));
+    EXPECT_FALSE(monomino->contains({0, -1}));
+    EXPECT_FALSE(monomino->contains({Config::GridSize, 0}));
+    EXPECT_FALSE(monomino->contains({0, Config::GridSize}));
+
+    EXPECT_TRUE(monomino->contains({0, 0}));
+    EXPECT_TRUE(monomino->contains({Config::GridSize - 1, 0}));
+    EXPECT_TRUE(monomino->contains({0, Config::GridSize - 1}));
+    EXPECT_TRUE(monomino->contains({Config::GridSize - 1, Config::GridSize - 1}));
+}
+
+TEST(PieceNodeTest, CShapeContains) 
+{
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+
+    // ID 14 (5 blocks C shape)    
+    auto cShape = std::make_unique<PieceNode>(14, Team::Blue, testTextures);
+    cShape->setPosition({0.f, 0.f});
+    EXPECT_EQ(cShape->getChildCount(), 5);
+   
+    // Outside
+    EXPECT_FALSE(cShape->contains({-1, 0}));
+    EXPECT_FALSE(cShape->contains({0, -1}));
+    EXPECT_FALSE(cShape->contains({Config::GridSize * 2, 0}));
+    EXPECT_FALSE(cShape->contains({0, Config::GridSize * 3}));
+    
+    // Hole
+    float gridMid = Config::GridSize / 2;
+
+    EXPECT_FALSE(cShape->contains({Config::GridSize, Config::GridSize}));
+    EXPECT_FALSE(cShape->contains({Config::GridSize, Config::GridSize + gridMid}));
+    EXPECT_FALSE(cShape->contains({Config::GridSize + gridMid, Config::GridSize}));
+    EXPECT_FALSE(cShape->contains({Config::GridSize + gridMid, Config::GridSize + gridMid}));
+    
+    // First Block
+    EXPECT_TRUE(cShape->contains({gridMid, gridMid}));
+
+    // Second Block
+    EXPECT_TRUE(cShape->contains({Config::GridSize + gridMid, gridMid}));
+
+    // Third Block
+    EXPECT_TRUE(cShape->contains({gridMid, Config::GridSize + gridMid}));
+
+    // Fourth Block
+    EXPECT_TRUE(cShape->contains({gridMid, Config::GridSize * 2 + gridMid}));
+
+    // Fifth Bock
+    EXPECT_TRUE(cShape->contains({Config::GridSize + gridMid, Config::GridSize * 2 + gridMid}));
 }

--- a/tests/client/Nodes/PieceNodeUnittest.cc
+++ b/tests/client/Nodes/PieceNodeUnittest.cc
@@ -1,0 +1,82 @@
+#include "MockTextureHolder.hpp"
+
+#include <gtest/gtest.h>
+#include "Nodes/PieceNode.hpp" 
+#include "SFML/Graphics/Texture.hpp"
+#include <SFML/Window/Context.hpp>
+
+
+TEST(PieceNodeTest, NumberOfBlocks) 
+{
+    // Use the real type PieceNode expects
+    MockTextureHolder testTextures;
+    // Create a blank 1x1 texture in memory (no file needed!)
+    sf::Texture dummy;
+    bool resized = dummy.resize({1, 1}); 
+    EXPECT_TRUE(resized);
+ 
+    // Insert it manually (assuming your ResourceHolder has a 'load' or 'insert' method)
+    testTextures.load(Textures::Tiles, "dummy_data");
+    // If your load() calls sf::Texture::loadFromFile, you might need a 
+    // specific 'insert' method in your ResourceHolder for testing.
+
+    std::array<int, Blokus::PolyominoCount> expectedNumBlocks;
+    auto pieces = Blokus::PolyominoGenerator::getData().polyominoById;
+    for (int id = 0; id < Blokus::PolyominoCount; ++id)
+    {
+        expectedNumBlocks[id] = pieces[id].blocks.size();
+    }
+     
+    for (int id = 0; id < Blokus::PolyominoCount; ++id)
+    {  
+        const Team blue = Team::Blue;
+        PieceNode piece(id, blue, testTextures);
+        EXPECT_EQ(piece.getChildCount(), expectedNumBlocks[id]);
+    } 
+}
+
+TEST(PieceNodeTest, IdentityManagement) 
+{
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+    
+    // Constructor test
+    PieceNode piece(0, Team::Red, testTextures);
+    EXPECT_EQ(piece.getId(), 0);
+
+    // setId() test
+    piece.setId(5);
+    EXPECT_EQ(piece.getId(), 5); 
+}
+
+TEST(PieceNodeTest, Color) 
+{
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+
+    PieceNode yellow(1, Team::Yellow, testTextures);
+    EXPECT_EQ(yellow.getTeam(), Team::Yellow);
+
+    PieceNode green(1, Team::Green, testTextures);
+    EXPECT_EQ(green.getTeam(), Team::Green);
+
+    PieceNode blue(1, Team::Blue, testTextures);
+    EXPECT_EQ(blue.getTeam(), Team::Blue);
+
+    PieceNode red(1, Team::Red, testTextures);
+    EXPECT_EQ(red.getTeam(), Team::Red);
+}
+
+TEST(PieceNodeTest, SetIdUpdatesBlocks) 
+{
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+
+    // Start with ID 0 (1 block)
+    PieceNode piece(0, Team::Blue, testTextures);
+    EXPECT_EQ(piece.getChildCount(), 1);
+
+    // Change to ID 1 (Suppose it has 2 blocks)
+    piece.setId(1);
+    EXPECT_EQ(piece.getChildCount(), 2); // The test now proves the layout updated!
+}

--- a/tests/client/Nodes/SceneNodeUnittest.cc
+++ b/tests/client/Nodes/SceneNodeUnittest.cc
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+#include "Nodes/SceneNode.hpp" 
+#include "SFML/Graphics/RenderTexture.hpp"
+
+
+TEST(SceneNodeTest, ParentChildRelationship) {
+    // No child test
+    SceneNode parent;
+    EXPECT_EQ(parent.getChildCount(), 0);
+    EXPECT_EQ(parent.getParent(), nullptr);
+
+    auto firstChild = std::make_unique<SceneNode>();
+    SceneNode* firstChildPtr = firstChild.get();
+
+    auto secondChild = std::make_unique<SceneNode>();
+    SceneNode* secondChildPtr = secondChild.get();
+
+    auto thirdChild = std::make_unique<SceneNode>();
+    SceneNode* thirdChildPtr = thirdChild.get();
+
+    // Attach first dhild and test
+    parent.attachChild(std::move(firstChild));
+    EXPECT_EQ(parent.getChildCount(), 1);
+    EXPECT_EQ(firstChildPtr->getParent(), &parent);
+
+    // Attach second child and test
+    parent.attachChild(std::move(secondChild));
+    EXPECT_EQ(parent.getChildCount(), 2);
+    EXPECT_EQ(firstChildPtr->getParent(), &parent);
+
+    // Attach third child to first child and test
+    firstChildPtr->attachChild(std::move(thirdChild));
+    EXPECT_EQ(firstChildPtr->getChildCount(), 1);
+    EXPECT_EQ(thirdChildPtr->getParent(), firstChildPtr);
+
+
+    // Detach second child with no child
+    auto detachedSecond = parent.detachChild(*secondChildPtr);
+    EXPECT_EQ(detachedSecond.get(), secondChildPtr);
+
+    EXPECT_EQ(parent.getChildCount(), 1);
+    EXPECT_EQ(detachedSecond->getParent(), nullptr);
+
+    // Detach first child with a child
+    auto detachedFirst = parent.detachChild(*firstChildPtr);
+    EXPECT_EQ(parent.getChildCount(), 0);
+    EXPECT_EQ(detachedFirst->getChildCount(), 1); 
+}
+
+TEST(SceneNodeTest, WorldTransformCalculation) {
+    // Test world position for no parent
+    SceneNode parent;
+    parent.setPosition({10.f, 10.f});
+    sf::Vector2f worldPos = parent.getWorldPosition();
+    EXPECT_FLOAT_EQ(worldPos.x, 10.f);
+    EXPECT_FLOAT_EQ(worldPos.y, 10.f);
+
+    // Test world position for child
+    auto child = std::make_unique<SceneNode>();
+    child->setPosition({5.f, 5.f});
+    SceneNode* childPtr = child.get();
+
+    parent.attachChild(std::move(child));
+
+    worldPos = childPtr->getWorldPosition();
+    EXPECT_FLOAT_EQ(worldPos.x, 15.f);
+    EXPECT_FLOAT_EQ(worldPos.y, 15.f);
+}
+
+TEST(SceneNodeTest, ReattachChild) {
+    SceneNode parentA, parentB;
+    auto child = std::make_unique<SceneNode>();
+    SceneNode* childPtr = child.get();
+
+    parentA.attachChild(std::move(child));
+    parentB.attachChild(parentA.detachChild(*childPtr)); // Standard move
+
+    EXPECT_EQ(childPtr->getParent(), &parentB);
+    EXPECT_EQ(parentA.getChildCount(), 0);
+}
+
+TEST(SceneNodeTest, RotationTransform) {
+    SceneNode parent;
+    // Clockwise 90 degrees
+    parent.setRotation(sf::degrees(90.f)); 
+
+    auto child = std::make_unique<SceneNode>();
+    child->setPosition({10.f, 5.f}); 
+    SceneNode* childPtr = child.get();
+
+    parent.attachChild(std::move(child));
+
+    sf::Vector2f worldPos = childPtr->getWorldPosition();
+    // After 90 deg rotation, (10, 5) becomes (-5, 10)
+    EXPECT_NEAR(worldPos.x, -5.f, 0.01f); 
+    EXPECT_NEAR(worldPos.y, 10.f, 0.01f);
+}

--- a/tests/client/Nodes/SceneNodeUnittest.cc
+++ b/tests/client/Nodes/SceneNodeUnittest.cc
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include "Nodes/SceneNode.hpp" 
-#include "SFML/Graphics/RenderTexture.hpp"
 
 
 TEST(SceneNodeTest, ParentChildRelationship) {

--- a/tests/client/Resource/ResourceHolderUnittest.cc
+++ b/tests/client/Resource/ResourceHolderUnittest.cc
@@ -1,95 +1,49 @@
 #include "Resource/ResourceHolder.hpp"
+#include "MockResource.hpp"
 
 #include "gtest/gtest.h"
 #include <memory>
 #include <stdexcept>
 
 namespace
-{
-    // Mock Resource class for testing
-    class MockResource
-    {
-    public:
-        MockResource() : mLoaded(false), mOpened(false) {}
-
-        bool loadFromFile(const std::string& filename)
+{ 
+    TEST(ResourceHolderTest, CorrectBranchingByErrorMessage) {
+        // 1. Test the Font branch (if branch)
+        ResourceHolder<sf::Font, ResourceID> fontHolder;
+        try 
         {
-            // Simulate failure for specific filenames
-            if (filename == "invalid.txt")
-                return false;
-            mLoaded = true;
-            mFileName = filename;
-            return true;
+            fontHolder.load(ResourceID::First, "non_existent.ttf");
+            FAIL() << "Should have thrown an exception";
+        } 
+        catch (const std::runtime_error& e) 
+        {
+            // This confirms it reached: "Failed to open font"
+            EXPECT_STREQ(e.what(), "ResourceHolder::load - Failed to open font non_existent.ttf");
         }
 
-        template <typename Parameter>
-        bool loadFromFile(const std::string& filename, const Parameter& param)
-        {
-            // Simulate failure for specific filenames
-            if (filename == "invalid_param.txt")
-                return false;
-            mLoaded = true;
-            mFileName = filename;
-            mParameter = std::to_string(param);
-            return true;
+        // 2. Test the Texture branch (else branch)
+        ResourceHolder<sf::Texture, ResourceID> textureHolder;
+        try {
+            textureHolder.load(ResourceID::First, "non_existent.png");
+            FAIL() << "Should have thrown an exception";
+        } catch (const std::runtime_error& e) {
+            // This confirms it reached: "Failed to load resource"
+            EXPECT_STREQ(e.what(), "ResourceHolder::load - Failed to load resource non_existent.png");
         }
-
-        bool openFromFile(const std::string& filename)
-        {
-            // Simulate failure for specific filenames
-            if (filename == "invalid_open.txt")
-                return false;
-            mOpened = true;
-            mFileName = filename;
-            return true;
-        }
-
-        bool isLoaded() const { return mLoaded; }
-        bool isOpened() const { return mOpened; }
-        const std::string& getFileName() const { return mFileName; }
-        const std::string& getParameter() const { return mParameter; }
-
-    private:
-        bool mLoaded;
-        bool mOpened;
-        std::string mFileName;
-        std::string mParameter;
-    };
-
-    // Identifier enum for testing
-    enum class ResourceID
-    {
-        First = 0,
-        Second = 1,
-        Third = 2
-    };
-
-    // Test: Round-trip integrity test with open() and get()
-    TEST(ResourceHolderTest, OpenAndGetRoundTrip)
-    {
-        ResourceHolder<MockResource, ResourceID> holder;
-
-        // Load resource using open()
-        holder.open(ResourceID::First, "test_file.txt");
-
-        // Get the resource and verify it was loaded correctly
-        const MockResource& resource = holder.get(ResourceID::First);
-        EXPECT_TRUE(resource.isOpened());
-        EXPECT_EQ(resource.getFileName(), "test_file.txt");
     }
-
-    // Test: Round-trip integrity test with load(id, filename) and get()
+    
+    // Test: Round-trip integrity test with open() and get()
     TEST(ResourceHolderTest, LoadAndGetRoundTrip)
     {
         ResourceHolder<MockResource, ResourceID> holder;
 
-        // Load resource using load(id, filename)
-        holder.load(ResourceID::Second, "resource.txt");
+        // Load resource using open()
+        holder.load(ResourceID::First, "test_file.txt");
 
         // Get the resource and verify it was loaded correctly
-        const MockResource& resource = holder.get(ResourceID::Second);
+        const MockResource& resource = holder.get(ResourceID::First);
         EXPECT_TRUE(resource.isLoaded());
-        EXPECT_EQ(resource.getFileName(), "resource.txt");
+        EXPECT_EQ(resource.getFileName(), "test_file.txt");
     }
 
     // Test: Round-trip integrity test with load(id, filename, param) and get()
@@ -98,25 +52,13 @@ namespace
         ResourceHolder<MockResource, ResourceID> holder;
 
         // Load resource using load(id, filename, parameter)
-        holder.load(ResourceID::Third, "resource_param.txt", 42);
+        holder.load(ResourceID::First, "resource_param.txt", 42);
 
         // Get the resource and verify it was loaded correctly
-        const MockResource& resource = holder.get(ResourceID::Third);
+        const MockResource& resource = holder.get(ResourceID::First);
         EXPECT_TRUE(resource.isLoaded());
         EXPECT_EQ(resource.getFileName(), "resource_param.txt");
         EXPECT_EQ(resource.getParameter(), "42");
-    }
-
-    // Test: Error handling for open() with invalid file
-    TEST(ResourceHolderTest, OpenErrorHandling)
-    {
-        ResourceHolder<MockResource, ResourceID> holder;
-
-        // Attempt to open an invalid file should throw
-        EXPECT_THROW(
-            holder.open(ResourceID::First, "invalid_open.txt"),
-            std::runtime_error
-        );
     }
 
     // Test: Error handling for load(id, filename) with invalid file
@@ -141,5 +83,19 @@ namespace
             holder.load(ResourceID::First, "invalid_param.txt", 99),
             std::runtime_error
         );
+    }
+
+    TEST(ResourceHolderDeathTest, AssertsOnMissingResource) 
+    {
+        ResourceHolder<sf::Texture, ResourceID> textures;
+        
+        // We expect the program to 'die' when we call get() for a missing ID
+        EXPECT_DEBUG_DEATH({
+            const auto& first = textures.get(ResourceID::First);
+        }, "");
+        
+        EXPECT_DEBUG_DEATH({
+            auto first = textures.get(ResourceID::First);
+        }, ""); 
     }
 }


### PR DESCRIPTION
# Description
## PieceNode
- Added PieceNode by rescaling within individual blocks and setting the blocks' positions within PieceNode.
- Added TextureHolder to PieceNode as a parameter
- Using a singleton Library to set blocks in the pieces based on piece id
- Implemented an updateLayout() pattern that handles dynamic child node creation/destruction, ensuring the scene graph stays synchronized with the Piece ID.
- Added contains method to check if a mouse touches any of its blocks

## Refactoring ResourceHolder
- Adjusted ResourceHolder member visibility to protected to facilitate inheritance-based mocking while maintaining encapsulation from external classes.
- Resolved a template instantiation error where sf::Font (SFML 3) lacked the loadFromFile method by utilizing if constexpr for compile-time branching.
- Marked load method as virtual to create Mock TextureHolder

## Technical Note
- Tested assert statement using EXPECT_DEBUG_DEATH


# Test
- Screen Recording

https://github.com/user-attachments/assets/d53c9031-bd5d-4968-a238-a4449e13c9b0




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hierarchical scene graph for more robust rendering and entity composition
  * Enhanced piece visualization with team support and dynamic block layouts
  * Configurable board geometry (board size increased to 12) and display metrics

* **Improvements**
  * Asset/resource loading enhanced with type-aware handling for fonts and textures

* **Tests**
  * Added comprehensive unit tests for scene graph, piece behavior, and resource handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->