### PR TITLE
PieceNode centroid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(FetchContent)
 FetchContent_Declare(SFML
     GIT_REPOSITORY https://github.com/SFML/SFML.git
     GIT_TAG 3.0.1
-    GIT_SHALLOW ON
+    GIT_PROGRESS ON
     EXCLUDE_FROM_ALL
     SYSTEM)
 FetchContent_MakeAvailable(SFML)
@@ -28,7 +28,7 @@ FetchContent_MakeAvailable(SFML)
 FetchContent_Declare(spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG v1.14.1   # latest as of 2025
-    GIT_SHALLOW ON
+    GIT_PROGRESS ON
     EXCLUDE_FROM_ALL
     SYSTEM)
 FetchContent_MakeAvailable(spdlog)
@@ -36,8 +36,8 @@ FetchContent_MakeAvailable(spdlog)
 # Fetch flatbuffers
 FetchContent_Declare(flatbuffers
   GIT_REPOSITORY https://github.com/google/flatbuffers.git
-  GIT_TAG        v23.5.26
-  GIT_SHALLOW    ON       
+  GIT_TAG v23.5.26
+  GIT_PROGRESS ON       
   EXCLUDE_FROM_ALL            
   SYSTEM                          
 )

--- a/include/client/Nodes/PieceNode.hpp
+++ b/include/client/Nodes/PieceNode.hpp
@@ -32,14 +32,20 @@ public:
 
     PieceState getState() const;
 
+    sf::Vector2f getCentroid() const;
+
 private:
     void updateLayout();
+
+    void setCentroid();
 
 private:
     int mCurrentId;
     const Team mTeam;
     PieceState mState;
     TextureHolder& mTextures;
+
+    sf::Vector2f mCentroid;
 };
 
 #endif

--- a/src/client/Nodes/PieceNode.cpp
+++ b/src/client/Nodes/PieceNode.cpp
@@ -32,8 +32,10 @@ PieceNode::PieceNode(int pieceId, const Team team, TextureHolder& textures)
     , mTeam(team)
     , mState(PieceState::Ready)
     , mTextures(textures)
+    , mCentroid()
 {
    updateLayout();
+   setCentroid();
 }
 
 int PieceNode::getId() const
@@ -78,5 +80,28 @@ void PieceNode::setState(PieceState state)
 PieceState PieceNode::getState() const
 {
     return mState;
+}
+
+void PieceNode::setCentroid()
+{
+    const auto &library = Blokus::PolyominoGenerator::getData();
+    const auto &coordinates = library.polyominoById.at(mCurrentId).blocks;
+
+    mCentroid = { 0.f, 0.f };
+    for (const auto& pos : coordinates) 
+    {
+        mCentroid.x += pos.x * Config::GridSize + Config::GridSize / 2.f;
+        mCentroid.y += pos.y * Config::GridSize + Config::GridSize / 2.f;
+    } 
+
+    mCentroid = { 
+        mCentroid.x / coordinates.size() , 
+        mCentroid.y / coordinates.size() 
+    };
+}
+
+sf::Vector2f PieceNode::getCentroid() const
+{
+    return mCentroid;
 }
 

--- a/tests/client/Nodes/PieceNodeUnittest.cc
+++ b/tests/client/Nodes/PieceNodeUnittest.cc
@@ -158,3 +158,21 @@ TEST(PieceNodeTest, CShapeContains)
     // Fifth Bock
     EXPECT_TRUE(cShape->contains({Config::GridSize + gridMid, Config::GridSize * 2 + gridMid}));
 }
+
+TEST(PieceNodeTest, ConstructorSetsOriginToCentroid) {
+    // 1. Setup Mock/Stub dependencies
+    MockTextureHolder testTextures;
+    testTextures.load(Textures::Tiles, "dummy_data");
+
+    // 2. Initialize Blue Domino (0, 0), (0, 1)
+    PieceNode piece(1, Team::Blue, testTextures);
+
+    // 3. Manually calculate expected centroid for validation
+    sf::Vector2f expectedCentroid = { Config::GridSize / 2.f, Config::GridSize };
+           
+    // 4. Assert
+    sf::Vector2f actualOrigin = piece.getCentroid();
+    
+    EXPECT_NEAR(actualOrigin.x, expectedCentroid.x, 0.001f);
+    EXPECT_NEAR(actualOrigin.y, expectedCentroid.y, 0.001f);
+} 


### PR DESCRIPTION
### Description
In the TrayNode, the pieces' origin are at (0, 0). However, when a client grabs a piece, the piece's origin shifts to its centroid to avoid movement of the mouse under piece rotation or reflection.

### Progress
Close #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centroid tracking for game pieces to improve positioning accuracy.

* **Chores**
  * Updated build configuration to display progress during dependency downloads instead of shallow cloning.

* **Tests**
  * Added unit tests to verify centroid calculation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->