### PR TITLE
Send update shadow Command

### DIFF
--- a/include/client/Config.hpp
+++ b/include/client/Config.hpp
@@ -3,6 +3,9 @@
 
 #include <SFML/System/Vector2.hpp>
 #include "shared/Constants.hpp"
+#include "shared/Team.hpp"
+
+#include "SFML/Graphics/Color.hpp"
 
 
 namespace Config {
@@ -19,6 +22,47 @@ namespace Config {
     const float TileSize = 512.f;
 
     const float Padding = 100.f;
+
+   
+    inline sf::Color getShadowColor(Team team) 
+    {
+        sf::Color color;
+        switch (team) 
+        {   
+            case Team::None:
+            {
+                color = sf::Color(128, 128, 128);
+                break;
+            }
+            case Team::Red:
+            {
+                color = sf::Color(255, 75, 51);
+                break;
+            }
+            case Team::Blue:
+            {
+                color = sf::Color(46, 154, 255);
+                break;
+            }
+            case Team::Yellow:
+            {
+                color = sf::Color(255, 215, 0);
+                break;
+            }
+            case Team::Green:
+            {
+                color = sf::Color(73, 209, 27);
+                break;
+            }
+            default:
+            {
+                assert(false && "Invalid Team!");
+            }
+        }
+
+        color.a = 120; 
+        return color;
+    }
 }
 
 #endif

--- a/include/client/Nodes/Arena.hpp
+++ b/include/client/Nodes/Arena.hpp
@@ -29,7 +29,7 @@ public:
     };
 
 public:
-    Arena(sf::RenderTarget& window, TextureHolder& textures, std::array<int, Blokus::DeckSize> deck, CommandQueue &commands);
+    Arena(sf::RenderTarget& window, TextureHolder& textures, std::array<int, Blokus::DeckSize> deck, CommandQueue &commands, Team team);
 
     void buildScene();
 

--- a/include/client/Nodes/BoardNode.hpp
+++ b/include/client/Nodes/BoardNode.hpp
@@ -17,17 +17,26 @@ public:
 
     sf::Vector2i getMinSnappedGrid(sf::Vector2f worldPos, sf::Vector2f minOffset) const override;
 
+    unsigned int getCategory() const override;
+
+    virtual void updateShadow(int pieceId, sf::Vector2i minSnappedGrid, sf::Color color);
 
 private:
     virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const override;
 
+    void drawShadow(sf::RenderTarget& target, sf::RenderStates states) const;
+
 private:
-    std::array<bool, TeamCount> mIsFirstMove;
+    struct Shadow
+    {
+        int pieceId;
+        sf::Vector2i minCoord; 
+        sf::Color color;
+    };
 
     sf::RectangleShape mBackground;
     sf::VertexArray mBoardLines;
 
-    std::array<int, TeamCount> mScores;
     std::array<Team, Blokus::BoardSize * Blokus::BoardSize> mBoard;
-
+    std::optional<Shadow> mShadow;
 };

--- a/include/client/Player.hpp
+++ b/include/client/Player.hpp
@@ -1,6 +1,7 @@
 #ifndef PLAYER_HPP
 #define PLAYER_HPP
 
+#include "shared/Team.hpp"
 #include "SFML/Window/Event.hpp"
 #include <map>
 
@@ -32,9 +33,13 @@ class Player
         
         void setQuery(TrayQuery* tray, BoardQuery* board);
 
+        void setTeam(Team team);
+        
         void handleEvent(const sf::Event& event, CommandQueue& commands);
 
         std::optional<int> getHeldPieceId() const;
+
+        Team getTeam() const;
 
     private:
         void pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands);
@@ -43,6 +48,8 @@ class Player
 
     private:
         sf::RenderWindow& mWindow;
+
+        Team mTeam = Team::None; 
 
         TrayQuery* mTrayPtr;
         BoardQuery* mBoardPtr;

--- a/src/client/Game.cpp
+++ b/src/client/Game.cpp
@@ -6,7 +6,6 @@
 #include "Nodes/BoardNode.hpp"
 
 #include <stdexcept>
-#include <iostream>
 
 
 const float Game::PlayerSpeed = 100.f;
@@ -23,13 +22,15 @@ Game::Game(FontHolder& fonts)
     , mTextures()
     , mFonts(fonts)
     , mStatistics()
-    , mArena(mWindow, mTextures, deck, mCommandQueue) 
+    , mArena(mWindow, mTextures, deck, mCommandQueue, Team::Red) 
     , mPlayer(mWindow)
 {
     updateView(mWindow.getSize());
     loadTextures();
     mArena.buildScene();
-    setQuery();     
+    setQuery();    
+
+    mPlayer.setTeam(Team::Red);
 }
 
 void Game::run()

--- a/src/client/Nodes/Arena.cpp
+++ b/src/client/Nodes/Arena.cpp
@@ -11,7 +11,7 @@
 #include <memory>
 
 
-Arena::Arena(sf::RenderTarget& target, TextureHolder& textures, std::array<int, Blokus::DeckSize> deck, CommandQueue& commands)
+Arena::Arena(sf::RenderTarget& target, TextureHolder& textures, std::array<int, Blokus::DeckSize> deck, CommandQueue& commands, Team team)
     : mTarget(target)
     , mTextures(textures)
     , mSceneLayers()
@@ -19,7 +19,7 @@ Arena::Arena(sf::RenderTarget& target, TextureHolder& textures, std::array<int, 
     , mTray(nullptr)
     , mCommands(commands)
     , mActiveTeam(Team::Red)
-    , mTeam(Team::Red)
+    , mTeam(team)
     , mDeck(deck)
 {
 }

--- a/src/client/Nodes/BoardNode.cpp
+++ b/src/client/Nodes/BoardNode.cpp
@@ -5,7 +5,7 @@
 
 
 BoardNode::BoardNode(TextureHolder& textures)
-: mBoardLines(sf::PrimitiveType::Lines, (Blokus::BoardSize + 1) * 4)
+    : mBoardLines(sf::PrimitiveType::Lines, (Blokus::BoardSize + 1) * 4)
 { // Should use private functions to organize code FirstMove, grid, background, score etc.
     float boardSize = Blokus::BoardSize * Config::GridSize;
     
@@ -48,6 +48,17 @@ sf::Vector2i BoardNode::getMinSnappedGrid(sf::Vector2f worldPos, sf::Vector2f mi
     return minSnappedGrid;
 }
 
+unsigned int BoardNode::getCategory() const
+{
+    return Category::Board;
+}
+
+void BoardNode::updateShadow(int pieceId, sf::Vector2i minSnappedGrid, sf::Color color)
+{
+    mShadow = { pieceId, minSnappedGrid, color };
+}
+
+
 void BoardNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const
 {
     // Draw background
@@ -56,7 +67,34 @@ void BoardNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) c
     // Draw grid lines
     target.draw(mBoardLines, states);
 
-    // Shadow piece is drawn by Arena's Interaction layer, not here
-    // This keeps shared visuals (Board, Tray) separate from player-specific (InteractionNode)
+    if (mShadow) 
+    {
+        drawShadow(target, states);
+    }
+}   
+
+void BoardNode::drawShadow(sf::RenderTarget& target, sf::RenderStates states) const
+{
+    const auto &library = Blokus::PolyominoGenerator::getData();
+    const auto &coordinates = library.polyominoById.at(mShadow->pieceId).blocks;
+
+    sf::RectangleShape rect(sf::Vector2f(Config::GridSize, Config::GridSize));
+    rect.setFillColor(mShadow->color);
+
+    for (const auto& offset : coordinates)
+    {
+        sf::Vector2i gridPos = mShadow->minCoord + offset;
+        if (gridPos.x >= 0 && gridPos.x < Blokus::BoardSize &&
+            gridPos.y >= 0 && gridPos.y < Blokus::BoardSize)
+        {
+            float px = gridPos.x * Config::GridSize;
+            float py = gridPos.y * Config::GridSize;
+            
+            rect.setPosition({px, py});
+            target.draw(rect, states); 
+        }
+    }
 }
+
+
 

--- a/src/client/Player.cpp
+++ b/src/client/Player.cpp
@@ -1,9 +1,11 @@
 #include "Player.hpp"
 
+#include "Config.hpp"
 #include "Command/CommandQueue.hpp"
 #include "Referee.hpp"
 #include "Nodes/Arena.hpp"
 #include "Nodes/PieceNode.hpp"
+#include "Nodes/BoardNode.hpp"
 #include "Query/TrayQuery.hpp"
 #include "Query/BoardQuery.hpp"
 
@@ -26,6 +28,11 @@ void Player::setQuery(TrayQuery* trayPtr, BoardQuery* boardPtr)
 
     assert(boardPtr != nullptr);
     mBoardPtr = boardPtr;
+}
+
+void Player::setTeam(Team team)
+{
+    mTeam = team;
 }
 
 void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
@@ -68,6 +75,10 @@ std::optional<int> Player::getHeldPieceId() const
     return std::nullopt;
 }
 
+Team Player::getTeam() const
+{
+    return mTeam;
+}
 
 void Player::pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands)
 {
@@ -96,9 +107,16 @@ void Player::pushMoveCommand(sf::Vector2f worldPos, CommandQueue& commands)
 
     assert(mHeldPiecePtr);
     sf::Vector2i minSnappedGrid = mBoardPtr->getMinSnappedGrid(worldPos, mHeldPiecePtr->getCentroid());
-    if (minSnappedGrid.x >= 0 && minSnappedGrid.x < Blokus::BoardSize &&
-        minSnappedGrid.y >= 0 && minSnappedGrid.y < Blokus::BoardSize) 
-    {
-        std::cout << minSnappedGrid.x << ", " << minSnappedGrid.y << "\n";
-    }
+    
+    int pieceId = mHeldPiecePtr->getId();
+    sf::Color color = Config::getShadowColor(mTeam);
+
+    Command shadow;
+    shadow.category = Category::Board;
+    shadow.action = derivedAction<BoardNode>([pieceId, minSnappedGrid, color](BoardNode& board, sf::Time) {
+        board.updateShadow(pieceId, minSnappedGrid, color);
+    });
+    commands.push(shadow);    
 }
+
+

--- a/tests/client/Mock/Nodes/MockBoardNode.hpp
+++ b/tests/client/Mock/Nodes/MockBoardNode.hpp
@@ -1,0 +1,28 @@
+#ifndef MOCK_BOARD_NODE_HPP
+#define MOCK_BOARD_NODE_HPP
+
+#include "Nodes/BoardNode.hpp"
+#include "Mock/Resource/MockTextureHolder.hpp"
+
+
+class MockBoardNode : public BoardNode 
+{
+public:
+    MockBoardNode(MockTextureHolder& textures)
+        : BoardNode(textures) 
+    {}
+
+    void updateShadow(int pieceId, sf::Vector2i coord, sf::Color color) override 
+    {
+        lastPieceId = pieceId;
+        lastCoord = coord;
+        lastColor = color;
+    }
+
+public:
+    int lastPieceId;
+    sf::Vector2i lastCoord;
+    sf::Color lastColor;
+}; 
+
+#endif

--- a/tests/client/Mock/Query/MockBoardQuery.hpp
+++ b/tests/client/Mock/Query/MockBoardQuery.hpp
@@ -1,11 +1,25 @@
+#ifndef MOCK_BOARD_QUERY_HPP
+#define MOCK_BOARD_QUERY_HPP
+
 #include "Query/BoardQuery.hpp"
 
+
 // A simple mock for the TrayQuery interface
-class MockBoardQuery : public BoardQuery {
+class MockBoardQuery : public BoardQuery 
+{
 public:
-    sf::Vector2i getMinSnappedGrid(sf::Vector2f worldPos, sf::Vector2f minOffset) const override
+    void setMinSnappedGrid(sf::Vector2i grid) 
     {
-        return {100, 100};
+        mReturnValue = grid;
     }
 
+    sf::Vector2i getMinSnappedGrid(sf::Vector2f worldPos, sf::Vector2f minOffset) const override
+    {
+        return mReturnValue;
+    }
+
+private:
+    sf::Vector2i mReturnValue = {0, 0};
 };
+
+#endif

--- a/tests/client/Mock/Query/MockTrayQuery.hpp
+++ b/tests/client/Mock/Query/MockTrayQuery.hpp
@@ -1,3 +1,6 @@
+#ifndef MOCK_TRAY_QUERY_HPP
+#define MOCK_TRAY_QUERY_HPP
+
 #include "Query/TrayQuery.hpp"
 #include "Mock/Resource/MockTextureHolder.hpp"
 #include "shared/Team.hpp"
@@ -32,3 +35,5 @@ private:
     MockTextureHolder& mTextures;
     std::vector<std::unique_ptr<PieceNode>> mPieceVault; 
 };
+
+#endif

--- a/tests/client/Mock/Resource/MockResource.hpp
+++ b/tests/client/Mock/Resource/MockResource.hpp
@@ -1,3 +1,6 @@
+#ifndef MOCK_RESOURCE_HPP
+#define MOCK_RESOURCE_HPP
+
 #include <string>
 
 
@@ -45,3 +48,5 @@ enum class ResourceID
 {
     First = 0 
 };
+
+#endif

--- a/tests/client/Mock/Resource/MockTextureHolder.hpp
+++ b/tests/client/Mock/Resource/MockTextureHolder.hpp
@@ -1,3 +1,6 @@
+#ifndef MOCK_TEXTUREHOLDER_HPP
+#define MOCK_TEXTUREHOLDER_HPP
+
 #include "Resource/ResourceHolder.hpp"
 #include "Resource/ResourceIdentifiers.hpp"
 
@@ -14,3 +17,5 @@ public:
         insertResource(id, std::move(dummy));
     }
 };
+
+#endif

--- a/tests/client/Nodes/ArenaUnittest.cc
+++ b/tests/client/Nodes/ArenaUnittest.cc
@@ -19,7 +19,7 @@ protected:
 
         mockTextures.load(Textures::ID::Tiles, "unused_path");
 
-        arena = std::make_unique<Arena>(target, mockTextures, deck, commands);
+        arena = std::make_unique<Arena>(target, mockTextures, deck, commands, Team::Blue);
         arena->buildScene();
     }
 

--- a/tests/client/PlayerUnittest.cc
+++ b/tests/client/PlayerUnittest.cc
@@ -4,6 +4,8 @@
 #include "Command/CommandQueue.hpp"
 #include "Mock/Query/MockTrayQuery.hpp"
 #include "Mock/Query/MockBoardQuery.hpp"
+#include "Mock/Nodes/MockBoardNode.hpp"
+#include "Config.hpp"
 
 
 class PlayerTest : public ::testing::Test {
@@ -34,6 +36,7 @@ protected:
     CommandQueue commands;
     std::unique_ptr<Player> player;
 };
+
 
 TEST_F(PlayerTest, ValidGrab) {
     // 1. Arrange
@@ -119,7 +122,6 @@ TEST_F(PlayerTest, DoubleGrab) {
 } 
 
 TEST_F(PlayerTest, Move) {
-    sf::Vector2f targetPos(500.f, 600.f);
     sf::Event moveEvent = sf::Event::MouseMoved{{500, 600}};
 
     player->handleEvent(moveEvent, commands);
@@ -135,14 +137,69 @@ TEST_F(PlayerTest, Move) {
 
     player->handleEvent(mousePressed, commands);
     
-    EXPECT_FALSE(commands.isEmpty());
-    Command cmd = commands.pop();
+    int size = 0;
+    while (!commands.isEmpty()) 
+    {
+        Command command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Arena);
+        ++size;
+    }
+    EXPECT_EQ(size, 1); 
         
     // Mouse Move
+    Team color = Team::Red;
+    sf::Vector2i grid = {300, 300};
+
+    player->setTeam(color);
+    mockBoard.setMinSnappedGrid(grid);
+    moveEvent = sf::Event::MouseMoved{{300, 300}};
     player->handleEvent(moveEvent, commands);
 
-    EXPECT_FALSE(commands.isEmpty());
-    cmd = commands.pop();
-    
-    EXPECT_EQ(cmd.category, Category::ActivePiece);
-}
+    size = 0;
+    while (!commands.isEmpty()) 
+    {
+        Command command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::ActivePiece);
+
+        command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
+
+        MockBoardNode spyBoard(mockTextures);
+        command.action(spyBoard, sf::Time::Zero);
+
+        EXPECT_EQ(spyBoard.lastPieceId, responseId);
+        EXPECT_EQ(spyBoard.lastCoord, grid);
+        EXPECT_EQ(spyBoard.lastColor, Config::getShadowColor(color));
+
+        ++size;
+    }
+    EXPECT_EQ(size, 1);
+
+    color = Team::Blue;
+    grid = {400, 400};
+
+    player->setTeam(color);
+    mockBoard.setMinSnappedGrid(grid);
+    moveEvent = sf::Event::MouseMoved{{300, 300}};
+    player->handleEvent(moveEvent, commands);
+
+    size = 0;
+    while (!commands.isEmpty()) 
+    {
+        Command command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::ActivePiece);
+
+        command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
+        
+        MockBoardNode spyBoard(mockTextures);
+        command.action(spyBoard, sf::Time::Zero);
+
+        EXPECT_EQ(spyBoard.lastPieceId, responseId);
+        EXPECT_EQ(spyBoard.lastCoord, grid);
+        EXPECT_EQ(spyBoard.lastColor, Config::getShadowColor(color));
+
+        ++size;
+    }
+    EXPECT_EQ(size, 1);
+} 


### PR DESCRIPTION
### Progress
- Closed #33 

### Description
- Found the best color for the shadow and added to Config.hpp
- Player sends update shadow command to BoardNode every time the mouse moves
- BoardNode updates shadow's configuration and draws shadow within the Board

### Rationale
- I didn't make the BoardNode hold a PieceNode for the shadow because it required holding a Tile, which makes the shadow heavy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Players can now be assigned to teams with persistent team tracking throughout gameplay.
  * Introduced shadow piece preview feature that displays potential piece placements on the board using team-specific colors as visual guidance before confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->