### PR TITLE
Transform piece in Player

### DIFF
--- a/include/client/Nodes/PieceNode.hpp
+++ b/include/client/Nodes/PieceNode.hpp
@@ -35,11 +35,6 @@ public:
 
     std::optional<int> getSlotId() const;
 
-    void setCategoryType(Category::Type category);
-
-    unsigned int getCategory() const;
-    
-
 private:
     void updateLayout();
 

--- a/include/client/Player.hpp
+++ b/include/client/Player.hpp
@@ -19,16 +19,6 @@ class PieceNode;
 class Player
 {
     public:
-        enum Transformation
-        {
-            RotateCW,
-            RotateCCW,
-            FlipH,
-            FlipV,
-            TransformationCount
-        };
-
-    public:
         Player(sf::RenderWindow& window);
         
         void setQuery(TrayQuery* tray, BoardQuery* board);
@@ -42,9 +32,23 @@ class Player
         Team getTeam() const;
 
     private:
-        void pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands);
+        enum Transformation
+        {
+            RotateCW,
+            RotateCCW,
+            ReflectH,
+            ReflectV,
+            TransformationCount
+        };
 
-        void pushMoveCommand(sf::Vector2f worldPos, CommandQueue& commands);
+    private:
+        void pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands) const;
+
+        void pushShadowCommand(sf::Vector2f worldPos, CommandQueue& command) const;
+        
+        int getTransformedId(int currentId, Transformation transform) const;
+
+        void initialzeKeys();
 
     private:
         sf::RenderWindow& mWindow;

--- a/src/client/Nodes/Arena.cpp
+++ b/src/client/Nodes/Arena.cpp
@@ -73,7 +73,6 @@ void Arena::grabPiece(int id, sf::Vector2f worldPos)
     piece->setOrigin(piece->getCentroid());
     piece->setPosition(worldPos); 
     
-    piece->setCategoryType(Category::ActivePiece);
     mSceneLayers[Action]->attachChild(std::move(piece));
 }
 

--- a/src/client/Nodes/PieceNode.cpp
+++ b/src/client/Nodes/PieceNode.cpp
@@ -48,6 +48,8 @@ void PieceNode::setId(int pieceId)
     mCurrentId = pieceId;
 
     updateLayout();
+    setCentroid();
+    setOrigin(mCentroid);
 }
 
 const Team PieceNode::getTeam() const

--- a/src/client/Nodes/PieceNode.cpp
+++ b/src/client/Nodes/PieceNode.cpp
@@ -106,13 +106,3 @@ std::optional<int> PieceNode::getSlotId() const
 {
     return mSlotId;
 }
-
-void PieceNode::setCategoryType(Category::Type category)
-{
-    mCategory = category;
-}
-
-unsigned int PieceNode::getCategory() const
-{
-    return mCategory;
-}

--- a/src/client/Player.cpp
+++ b/src/client/Player.cpp
@@ -19,6 +19,7 @@ Player::Player(sf::RenderWindow& window)
     , mBoardPtr(nullptr)
     , mHeldPiecePtr(nullptr) 
 {
+    initialzeKeys();
 }
 
 void Player::setQuery(TrayQuery* trayPtr, BoardQuery* boardPtr)
@@ -43,18 +44,15 @@ void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
         {
             sf::Vector2i mousePos = mouseMoved->position;
             sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);
-            pushMoveCommand(worldPos, commands);
-        }
+            mHeldPiecePtr->setPosition(worldPos);
+        } 
     }
 
     if (auto mousePressed = event.getIf<sf::Event::MouseButtonPressed>())
     {
-        // If mouse touched a piece
         if (mousePressed->button == sf::Mouse::Button::Left 
-            && !mHeldPiecePtr) //mReferee.canGrab ->optional PiecePtr
+            && !mHeldPiecePtr) 
         {
-            // 1. Ask Referee: "Is there a piece at this mouse coordinate?"
-            // Referee returns the Piece ID if found, otherwise nullopt.
             sf::Vector2i mousePos = mousePressed->position;
             sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);            
             if (auto piecePtr = mTrayPtr->getPieceAt(worldPos))
@@ -63,6 +61,24 @@ void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
                 pushGrabCommand(worldPos, commands);
             }
         } 
+    }
+
+    if (auto keyPressed = event.getIf<sf::Event::KeyPressed>()) 
+    { // Use function to set the id immediately to change shadow's id
+        auto it = mKeyBinding.find(keyPressed->code);
+        if (it != mKeyBinding.end() && mHeldPiecePtr) 
+        {
+            int pieceId = mHeldPiecePtr->getId(); 
+            mHeldPiecePtr->setId(getTransformedId(pieceId, it->second));
+        }
+    }
+
+    if (mHeldPiecePtr)
+    { // Check shadow 60 times every second
+        sf::Vector2i mousePos = sf::Mouse::getPosition(mWindow);
+        sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);
+        
+        pushShadowCommand(worldPos, commands);
     }
 }
 
@@ -80,7 +96,7 @@ Team Player::getTeam() const
     return mTeam;
 }
 
-void Player::pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands)
+void Player::pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands) const
 {
     Command grab;
     grab.category = Category::Arena;
@@ -93,18 +109,8 @@ void Player::pushGrabCommand(sf::Vector2f worldPos, CommandQueue& commands)
     commands.push(grab);
 }
 
-void Player::pushMoveCommand(sf::Vector2f worldPos, CommandQueue& commands)
+void Player::pushShadowCommand(sf::Vector2f worldPos, CommandQueue& commands) const
 {
-    Command move;
-    move.category = Category::ActivePiece;
-    move.action = derivedAction<PieceNode>(
-        [worldPos](PieceNode& piece, sf::Time) 
-    {
-        piece.setPosition(worldPos);
-    });
-
-    commands.push(move); 
-
     assert(mHeldPiecePtr);
     sf::Vector2i minSnappedGrid = mBoardPtr->getMinSnappedGrid(worldPos, mHeldPiecePtr->getCentroid());
     
@@ -117,6 +123,63 @@ void Player::pushMoveCommand(sf::Vector2f worldPos, CommandQueue& commands)
         board.updateShadow(pieceId, minSnappedGrid, color);
     });
     commands.push(shadow);    
+}
+
+void Player::initialzeKeys()
+{
+    mKeyBinding[sf::Keyboard::Key::R] = RotateCW;
+    mKeyBinding[sf::Keyboard::Key::C] = RotateCCW;
+    mKeyBinding[sf::Keyboard::Key::H] = ReflectH;
+    mKeyBinding[sf::Keyboard::Key::V] = ReflectV;
+}
+
+int Player::getTransformedId(int currentId, Transformation transform) const
+{
+    assert(currentId >= 0 && currentId < Blokus::PolyominoCount);
+    const auto& library = Blokus::PolyominoGenerator::getData();
+
+    switch(transform) 
+    {
+        case Transformation::RotateCW: 
+        {
+            return library.clockwiseRotatedIds.at(currentId);
+        }
+
+        case Transformation::RotateCCW: 
+        {
+            // Rotate CCW = Rotate CW three times
+            int id = currentId;
+            for (int i = 0; i < 3; ++i)
+            {
+                id = library.clockwiseRotatedIds.at(id);
+            }
+            
+            return id;
+        }
+
+        case Transformation::ReflectH: 
+        {
+            return library.horizontallyReflectedIds.at(currentId);
+        }
+
+        case Transformation::ReflectV:
+        {
+            // Vertical Flip = Horizontal Flip -> Rotate CW -> Rotate CW
+            int id = library.horizontallyReflectedIds.at(currentId);
+            
+            for (int i = 0; i < 2; ++i)
+            {
+                id = library.clockwiseRotatedIds.at(id);
+            }
+
+            return id; 
+        }
+
+        default:
+        {
+            assert(false && "Invalid Transformation!");
+        }
+    }
 }
 
 

--- a/tests/client/Nodes/ArenaUnittest.cc
+++ b/tests/client/Nodes/ArenaUnittest.cc
@@ -55,8 +55,6 @@ TEST_F(ArenaTest, GrabPiece) {
     EXPECT_EQ(grabbedPiece->getId(), targetId);
     EXPECT_EQ(grabbedPiece->getPosition(), targetPos);
 
-    EXPECT_EQ(grabbedPiece->getCategory(), Category::ActivePiece);
-    
     // Verify Origin is set to Centroid
     // (Assuming PieceNode has a getCentroid method)
     EXPECT_EQ(grabbedPiece->getOrigin(), grabbedPiece->getCentroid());

--- a/tests/client/PlayerUnittest.cc
+++ b/tests/client/PlayerUnittest.cc
@@ -242,6 +242,7 @@ TEST_F(PlayerTest, Transform) {
     ASSERT_TRUE(player->getHeldPieceId().has_value());
     EXPECT_EQ(player->getHeldPieceId().value(), cwId); 
 
+    // Rotate CCW
     sf::Event ccwEvent = sf::Event::KeyPressed{sf::Keyboard::Key::C};
     player->handleEvent(ccwEvent, commands);
 

--- a/tests/client/PlayerUnittest.cc
+++ b/tests/client/PlayerUnittest.cc
@@ -5,6 +5,7 @@
 #include "Mock/Query/MockTrayQuery.hpp"
 #include "Mock/Query/MockBoardQuery.hpp"
 #include "Mock/Nodes/MockBoardNode.hpp"
+#include "shared/PolyominoUtil.hpp"
 #include "Config.hpp"
 
 
@@ -60,6 +61,9 @@ TEST_F(PlayerTest, ValidGrab) {
     {
         Command command = commands.pop(); 
         EXPECT_EQ(command.category, Category::Arena);
+
+        command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
 
@@ -102,22 +106,39 @@ TEST_F(PlayerTest, DoubleGrab) {
     {
         Command command = commands.pop(); 
         EXPECT_EQ(command.category, Category::Arena);
+
+        command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
 
     EXPECT_EQ(size, 1);
 
     // 2. Act: Click again
+    size = 0;
     player->handleEvent(mousePressed, commands);
-    EXPECT_TRUE(commands.isEmpty());
+    while (!commands.isEmpty()) 
+    {
+        Command command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
+        ++size;
+    }
+    EXPECT_EQ(size, 1);
     EXPECT_EQ(player->getHeldPieceId(), 7);
     
     // 3. Assert
     responseId = 8;
     mockTray.setPiece(responseId);
 
+    size = 0;
     player->handleEvent(mousePressed, commands);
-    EXPECT_TRUE(commands.isEmpty());
+    while (!commands.isEmpty()) 
+    {
+        Command command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
+        ++size;
+    } 
+    EXPECT_EQ(size, 1);
     EXPECT_EQ(player->getHeldPieceId(), 7);
 } 
 
@@ -142,6 +163,9 @@ TEST_F(PlayerTest, Move) {
     {
         Command command = commands.pop(); 
         EXPECT_EQ(command.category, Category::Arena);
+
+        command = commands.pop(); 
+        EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
     EXPECT_EQ(size, 1); 
@@ -159,9 +183,6 @@ TEST_F(PlayerTest, Move) {
     while (!commands.isEmpty()) 
     {
         Command command = commands.pop(); 
-        EXPECT_EQ(command.category, Category::ActivePiece);
-
-        command = commands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
 
         MockBoardNode spyBoard(mockTextures);
@@ -187,9 +208,6 @@ TEST_F(PlayerTest, Move) {
     while (!commands.isEmpty()) 
     {
         Command command = commands.pop(); 
-        EXPECT_EQ(command.category, Category::ActivePiece);
-
-        command = commands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         
         MockBoardNode spyBoard(mockTextures);
@@ -203,3 +221,46 @@ TEST_F(PlayerTest, Move) {
     }
     EXPECT_EQ(size, 1);
 } 
+
+TEST_F(PlayerTest, Transform) {
+    Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::getData();
+
+    int initialId = 19; 
+    mockTray.setPiece(initialId);
+    
+    // Simulate a grab (Left click)
+    sf::Event::MouseButtonPressed pressEvent;
+    pressEvent.button = sf::Mouse::Button::Left;
+    pressEvent.position = {100, 100};
+    player->handleEvent(pressEvent, commands);
+
+    // Rotate CW
+    sf::Event cwEvent = sf::Event::KeyPressed{sf::Keyboard::Key::R};
+    player->handleEvent(cwEvent, commands);
+
+    int cwId = library.clockwiseRotatedIds[initialId];
+    ASSERT_TRUE(player->getHeldPieceId().has_value());
+    EXPECT_EQ(player->getHeldPieceId().value(), cwId); 
+
+    sf::Event ccwEvent = sf::Event::KeyPressed{sf::Keyboard::Key::C};
+    player->handleEvent(ccwEvent, commands);
+
+    ASSERT_TRUE(player->getHeldPieceId().has_value());
+    EXPECT_EQ(player->getHeldPieceId().value(), initialId); 
+
+    // Horizontal Reflection
+    int hId = library.horizontallyReflectedIds[initialId];
+    sf::Event hEvent = sf::Event::KeyPressed{sf::Keyboard::Key::H};
+    player->handleEvent(hEvent, commands);
+
+    ASSERT_TRUE(player->getHeldPieceId().has_value());
+    EXPECT_EQ(player->getHeldPieceId().value(), hId); 
+
+    // Vertical Reflection
+    int vId = library.clockwiseRotatedIds[cwId];
+    sf::Event vEvent = sf::Event::KeyPressed{sf::Keyboard::Key::V};
+    player->handleEvent(vEvent, commands);
+
+    ASSERT_TRUE(player->getHeldPieceId().has_value());
+    EXPECT_EQ(player->getHeldPieceId().value(), vId); 
+}


### PR DESCRIPTION
### Progress
- Closes #15 

### Description
- Eliminated `Category` from `PieceNode` and replaced with `setPostion`
- Used `PieceNode`'s function `setId` to transform a Piece
- Moved update shadow command to send the command if holding a piece

### Rationale
- I couldn't send command to set Piece ID then update shadow on the board because the new PieceNode's centroid is unknown
- I updated PieceNode immediately using a function to save its new centroid then sent a command to update the shadows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard controls for piece transformations (rotate and reflect).
  * Enhanced mouse interaction with shadow preview when dragging pieces.

* **Refactor**
  * Reorganized internal command system and simplified piece state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->