### PR TITLE
Checks to Referee for shadow color

### DIFF
--- a/include/client/Player.hpp
+++ b/include/client/Player.hpp
@@ -2,6 +2,7 @@
 #define PLAYER_HPP
 
 #include "shared/Team.hpp"
+#include "shared/Referee.hpp"
 #include "SFML/Window/Event.hpp"
 #include <map>
 
@@ -10,7 +11,6 @@ namespace sf
     class RenderWindow;
 }
 
-class Referee;
 class CommandQueue;
 class TrayQuery;
 class BoardQuery;
@@ -52,6 +52,7 @@ class Player
 
     private:
         sf::RenderWindow& mWindow;
+        Referee mReferee;
 
         Team mTeam = Team::None; 
 

--- a/include/shared/Referee.hpp
+++ b/include/shared/Referee.hpp
@@ -1,0 +1,43 @@
+#ifndef REFEREE_HPP
+#define REFEREE_HPP
+
+#include "shared/Team.hpp"
+#include "shared/Constants.hpp"
+#include "shared/PolyominoUtil.hpp"
+
+
+class Referee 
+{   
+public:
+    Referee();
+
+    bool isValid(int pieceId, sf::Vector2i minOffset, Team team) const;
+
+private:
+    bool canFit(const std::vector<sf::Vector2i>& blocks) const;
+
+    bool isStartValid(const std::vector<sf::Vector2i>& blocks, Team team) const;
+
+    bool hasCornerContact(const std::vector<sf::Vector2i>& corners, Team team) const;
+
+    bool hasEdgeContact(const std::vector<sf::Vector2i>& edges, Team team) const;
+
+    bool isWithinBound(const sf::Vector2i& pos) const;
+
+    std::vector<sf::Vector2i> getBlockPositions(int pieceId, sf::Vector2i minOffset) const;
+      
+    std::vector<sf::Vector2i> getEdgePositions(int pieceId, sf::Vector2i minOffset) const;
+   
+    std::vector<sf::Vector2i> getCornerPositions(int pieceId, sf::Vector2i minOffset) const;
+
+private:
+    const Blokus::PolyominoDefinition& library;
+    
+    std::array<bool, TeamCount> mIsFirstMove;
+    std::array<sf::Vector2i, TeamCount> mStartPos;
+    std::array<int, TeamCount> mScores;
+    std::array<Team, Blokus::BoardSize * Blokus::BoardSize> mBoard;
+};
+
+
+#endif

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -8,6 +8,7 @@ set_source_files_properties("${GEN_HEADER}" PROPERTIES GENERATED TRUE)
 set(SHARED_SOURCES
     PolyominoUtil.cpp
     PolyominoLoader.cpp
+    Referee.cpp
 )
 
 set_source_files_properties(${SHARED_SOURCES} PROPERTIES 

--- a/src/shared/Referee.cpp
+++ b/src/shared/Referee.cpp
@@ -1,0 +1,146 @@
+#include "shared/Referee.hpp"
+
+#include <cassert>
+
+Referee::Referee()
+    : library(Blokus::PolyominoGenerator::getData())
+{
+    for (int team = 0; team < TeamCount; ++team)
+    {
+        mIsFirstMove[team] = true;
+        mScores[team] = 0;
+
+        int x = (team & (1 << 0) ? Blokus::BoardSize - 1 : 0);
+        int y = (team & (1 << 1) ? Blokus::BoardSize - 1 : 0);
+        mStartPos[team] = { x, y };
+    }
+
+    for (int x = 0; x < Blokus::BoardSize; ++x)
+    {
+        for (int y = 0; y < Blokus::BoardSize; ++y)
+        {
+            mBoard[Blokus::getIndex(x, y)] = Team::None;
+        }
+    }
+}
+
+bool Referee::isValid(int pieceId, sf::Vector2i minOffset, Team team) const
+{
+    auto blocks = getBlockPositions(pieceId, minOffset);
+    auto edges = getEdgePositions(pieceId, minOffset);
+    auto corners = getCornerPositions(pieceId, minOffset);
+
+    if (!canFit(blocks) ||
+        (mIsFirstMove[team] && !isStartValid(blocks, team)) ||
+        (!mIsFirstMove[team] && !hasCornerContact(corners, team)) ||
+        hasEdgeContact(edges, team)) 
+    {
+        return false;
+    }
+    
+    return true;
+}
+
+bool Referee::canFit(const std::vector<sf::Vector2i>& blocks) const
+{
+    for (const auto pos : blocks) {
+        if (!isWithinBound(pos))
+        {
+            return false;
+        }
+        if (mBoard[Blokus::getIndex(pos.x, pos.y)] != Team::None) 
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool Referee::isStartValid(const std::vector<sf::Vector2i>& blocks, Team team) const  
+{
+    assert(mIsFirstMove[team] && "Needs to be first move!");
+    
+    for (const auto pos : blocks) {
+        if (pos == mStartPos[team]) 
+        {
+            return true;
+        }
+    }
+
+    return false; 
+}
+
+bool Referee::hasCornerContact(const std::vector<sf::Vector2i>& corners, Team team) const
+{
+    assert(!mIsFirstMove[team] && "Must not be first move!");
+
+    for (const auto pos : corners) 
+    {
+        if (isWithinBound(pos) && 
+        mBoard[Blokus::getIndex(pos.x, pos.y)] == team) 
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool Referee::hasEdgeContact(const std::vector<sf::Vector2i>& edges, Team team) const
+{
+    for (const auto pos : edges) 
+    {
+        if (isWithinBound(pos) && 
+        mBoard[Blokus::getIndex(pos.x, pos.y)] == team) 
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool Referee::isWithinBound(const sf::Vector2i& pos) const
+{
+    return !(pos.x < 0 || pos.x >= Blokus::BoardSize || 
+        pos.y < 0 || pos.y >= Blokus::BoardSize);
+}
+
+std::vector<sf::Vector2i> Referee::getBlockPositions(int pieceId, sf::Vector2i minOffset) const
+{
+    std::vector<sf::Vector2i> blockPositions;
+    blockPositions.reserve(Blokus::MaxBlocks);
+    const auto& blocks = library.polyominoById.at(pieceId).blocks;
+    for (auto pos : blocks) 
+    {
+        blockPositions.push_back(minOffset + pos);
+    }
+    return blockPositions;
+}
+
+std::vector<sf::Vector2i> Referee::getEdgePositions(int pieceId, sf::Vector2i minOffset) const
+{
+    std::vector<sf::Vector2i> edgePositions;
+    const auto& edges = library.polyominoById.at(pieceId).sensors.edges;;
+    for (auto pos : edges) 
+    {
+        edgePositions.push_back(minOffset + pos);
+    }
+
+    return edgePositions;
+}
+
+std::vector<sf::Vector2i> Referee::getCornerPositions(int pieceId, sf::Vector2i minOffset) const
+{
+    std::vector<sf::Vector2i> cornerPositions;
+    const auto& corners = library.polyominoById.at(pieceId).sensors.corners;;
+    for (auto pos : corners) 
+    {
+        cornerPositions.push_back(minOffset + pos);
+    }
+
+    return cornerPositions;
+}
+
+

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(BlokusSharedTests
     PolyominoLoaderUnittest.cc
     PolyominoUtilsUnittest.cc
+    RefereeUnittest.cc
     # add other test files here
 
 )

--- a/tests/shared/RefereeUnittest.cc
+++ b/tests/shared/RefereeUnittest.cc
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include "shared/Referee.hpp"
+
+
+TEST(RefereeTest, Boundary) {
+    Referee referee; 
+    
+    EXPECT_FALSE(referee.isValid(0, {-1, 0}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {0, -1}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize, 0}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize}, Team::Red));
+
+    EXPECT_FALSE(referee.isValid(0, {-1, 0}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(0, {0, -1}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize, 0}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize}, Team::Blue));
+
+    EXPECT_FALSE(referee.isValid(0, {-1, 0}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(0, {0, -1}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize, 0}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize}, Team::Yellow));
+
+    EXPECT_FALSE(referee.isValid(0, {-1, 0}, Team::Green));
+    EXPECT_FALSE(referee.isValid(0, {0, -1}, Team::Green));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize, 0}, Team::Green));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize}, Team::Green));
+}
+
+TEST(RefereeTest, Start) {
+    Referee referee;
+    
+    // Piece 0 (monomino)
+    EXPECT_TRUE(referee.isValid(0, {0, 0}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize - 1, 0}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize - 1}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Red)); 
+    
+    EXPECT_FALSE(referee.isValid(0, {0, 0}, Team::Blue));
+    EXPECT_TRUE(referee.isValid(0, {Blokus::BoardSize - 1, 0}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize - 1}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Blue));
+
+    EXPECT_FALSE(referee.isValid(0, {0, 0}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize - 1, 0}, Team::Yellow));
+    EXPECT_TRUE(referee.isValid(0, {0, Blokus::BoardSize - 1}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Yellow));
+
+    EXPECT_FALSE(referee.isValid(0, {0, 0}, Team::Green));
+    EXPECT_FALSE(referee.isValid(0, {Blokus::BoardSize - 1, 0}, Team::Green));
+    EXPECT_FALSE(referee.isValid(0, {0, Blokus::BoardSize - 1}, Team::Green));
+    EXPECT_TRUE(referee.isValid(0, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Green));
+
+    // Piece 1 (horizontal domino)
+    EXPECT_TRUE(referee.isValid(1, {0, 0}, Team::Red));
+    EXPECT_FALSE(referee.isValid(1, {Blokus::BoardSize - 1, 0}, Team::Red));
+    EXPECT_FALSE(referee.isValid(1, {0, Blokus::BoardSize - 1}, Team::Red));
+    EXPECT_FALSE(referee.isValid(1, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Red)); 
+    
+    EXPECT_FALSE(referee.isValid(1, {0, 0}, Team::Blue));
+    EXPECT_TRUE(referee.isValid(1, {Blokus::BoardSize - 1, 0}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(1, {0, Blokus::BoardSize - 1}, Team::Blue));
+    EXPECT_FALSE(referee.isValid(1, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Blue));
+
+    EXPECT_FALSE(referee.isValid(1, {0, 0}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(1, {Blokus::BoardSize - 1, 0}, Team::Yellow));
+    EXPECT_TRUE(referee.isValid(1, {0, Blokus::BoardSize - 2}, Team::Yellow));
+    EXPECT_FALSE(referee.isValid(1, {Blokus::BoardSize - 1, Blokus::BoardSize - 1}, Team::Yellow));
+
+    EXPECT_FALSE(referee.isValid(1, {0, 0}, Team::Green));
+    EXPECT_FALSE(referee.isValid(1, {Blokus::BoardSize - 1, 0}, Team::Green));
+    EXPECT_FALSE(referee.isValid(1, {0, Blokus::BoardSize - 1}, Team::Green));
+    EXPECT_TRUE(referee.isValid(1, {Blokus::BoardSize - 1, Blokus::BoardSize - 2}, Team::Green));
+}
+ 


### PR DESCRIPTION
### Progress
- Closed #38 

### Description
- Added four checks to Referee for shadow color

### Referee Creation
- I believe that Referee will be only used by Player, which sends its placement via a command to Arena, so I made the Player contain Referee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a game rule validation system for piece placements, ensuring pieces respect board boundaries, starting positions, and contact rules across all teams.

* **Tests**
  * Added comprehensive unit tests for validating piece placement rules and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->