### PR TITLE
Place Piece with Referee validation

### DIFF
--- a/include/client/Config.hpp
+++ b/include/client/Config.hpp
@@ -8,7 +8,8 @@
 #include "SFML/Graphics/Color.hpp"
 
 
-namespace Config {
+namespace Config 
+{
     const unsigned int ScreenWidth = 1920;
     const unsigned int ScreenHeight = 1080;
     
@@ -22,47 +23,6 @@ namespace Config {
     const float TileSize = 512.f;
 
     const float Padding = 100.f;
-
-   
-    inline sf::Color getShadowColor(Team team) 
-    {
-        sf::Color color;
-        switch (team) 
-        {   
-            case Team::None:
-            {
-                color = sf::Color(128, 128, 128);
-                break;
-            }
-            case Team::Red:
-            {
-                color = sf::Color(255, 75, 51);
-                break;
-            }
-            case Team::Blue:
-            {
-                color = sf::Color(46, 154, 255);
-                break;
-            }
-            case Team::Yellow:
-            {
-                color = sf::Color(255, 215, 0);
-                break;
-            }
-            case Team::Green:
-            {
-                color = sf::Color(73, 209, 27);
-                break;
-            }
-            default:
-            {
-                assert(false && "Invalid Team!");
-            }
-        }
-
-        color.a = 120; 
-        return color;
-    }
 }
 
 #endif

--- a/include/client/Game.hpp
+++ b/include/client/Game.hpp
@@ -42,6 +42,7 @@ class Game
         sf::RenderWindow mWindow;
         sf::View mMainView;
 
+        Referee mReferee;
         Arena mArena;
         Player mPlayer;
         CommandQueue mCommandQueue;

--- a/include/client/Game.hpp
+++ b/include/client/Game.hpp
@@ -7,6 +7,7 @@
 #include "Nodes/Arena.hpp"
 #include "Player.hpp"
 #include "Command/CommandQueue.hpp"
+#include "shared/Referee.hpp"
 
 #include <SFML/System/Time.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>

--- a/include/client/Nodes/Arena.hpp
+++ b/include/client/Nodes/Arena.hpp
@@ -7,11 +7,11 @@
 #include "shared/Team.hpp"
 #include "shared/Constants.hpp"
 
- 
+class Referee;
 class CommandQueue;
 class BoardNode;
 class TrayNode;
-class ActiveNode;
+
 
 namespace sf
 {
@@ -29,7 +29,9 @@ public:
     };
 
 public:
-    Arena(sf::RenderTarget& window, TextureHolder& textures, std::array<int, Blokus::DeckSize> deck, CommandQueue &commands, Team team);
+    Arena(sf::RenderTarget& window, TextureHolder& textures, 
+        std::array<int, Blokus::DeckSize> deck, 
+        CommandQueue &commands, Team team);
 
     void buildScene();
 
@@ -37,9 +39,11 @@ public:
 
     void grabPiece(int id, sf::Vector2f worldPos);
 
-    TrayNode* getTrayNode() const;
+    virtual void placePiece(sf::Vector2i gridCoord);
 
-    BoardNode* getBoardNode() const; 
+    TrayNode* getTrayNodePtr() const;
+
+    BoardNode* getBoardNodePtr() const; 
 
     SceneNode* getLayer(Layer layer) const;
 
@@ -51,8 +55,9 @@ private:
     CommandQueue& mCommands;
 
     // The Visual Layers (Added as children in constructor)
-    BoardNode* mBoard;
-    TrayNode* mTray;
+    BoardNode* mBoardPtr;
+    TrayNode* mTrayPtr;
+    SceneNode* mActivePiecePtr;
 
     Team mActiveTeam;
     const Team mTeam;

--- a/include/client/Nodes/BoardNode.hpp
+++ b/include/client/Nodes/BoardNode.hpp
@@ -1,3 +1,6 @@
+#ifndef BOARDNODE_HPP
+#define BOARDNODE_HPP
+
 #include "PieceNode.hpp"
 
 #include "Resource/ResourceIdentifiers.hpp"
@@ -6,12 +9,13 @@
 #include "Query/BoardQuery.hpp"
 
 #include "SFML/Graphics/RectangleShape.hpp"
+#include "SFML/Graphics/Sprite.hpp"
 
 
 class BoardNode : public SceneNode , public BoardQuery
 {
 public:
-    BoardNode(TextureHolder& textures);
+    BoardNode();
 
     sf::FloatRect getGlobalBounds() const;
 
@@ -21,9 +25,11 @@ public:
 
     virtual void updateShadow(int pieceId, sf::Vector2i minSnappedGrid, sf::Color color);
 
+    void addPiece(std::unique_ptr<PieceNode> piece, sf::Vector2i gridPos);
+ 
 private:
     virtual void drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const override;
-
+    
     void drawShadow(sf::RenderTarget& target, sf::RenderStates states) const;
 
 private:
@@ -34,9 +40,11 @@ private:
         sf::Color color;
     };
 
+private:
     sf::RectangleShape mBackground;
     sf::VertexArray mBoardLines;
 
-    std::array<Team, Blokus::BoardSize * Blokus::BoardSize> mBoard;
     std::optional<Shadow> mShadow;
 };
+
+#endif

--- a/include/client/Nodes/PieceNode.hpp
+++ b/include/client/Nodes/PieceNode.hpp
@@ -9,6 +9,7 @@
 #include "Resource/ResourceIdentifiers.hpp"
 #include "Nodes/SceneNode.hpp"
 #include "Command/Category.hpp"
+#include "Utility.hpp"
 
 
 enum class PieceState

--- a/include/client/Nodes/PieceNode.hpp
+++ b/include/client/Nodes/PieceNode.hpp
@@ -11,6 +11,8 @@
 #include "Command/Category.hpp"
 #include "Utility.hpp"
 
+#include <optional>
+
 
 enum class PieceState
 {

--- a/include/client/Nodes/TrayNode.hpp
+++ b/include/client/Nodes/TrayNode.hpp
@@ -15,7 +15,7 @@
 class TrayNode : public SceneNode, public TrayQuery
 {
 public:
-	typedef std::unique_ptr<PieceNode> PiecePtr;    
+	using PiecePtr = std::unique_ptr<PieceNode>;    
 
     public:
     TrayNode(TextureHolder& textures);

--- a/include/client/Player.hpp
+++ b/include/client/Player.hpp
@@ -19,7 +19,7 @@ class PieceNode;
 class Player
 {
     public:
-        Player(sf::RenderWindow& window);
+        Player(sf::RenderWindow& window, Referee& referee);
         
         void setQuery(TrayQuery* tray, BoardQuery* board);
 
@@ -46,19 +46,23 @@ class Player
 
         void pushShadowCommand(sf::Vector2f worldPos, CommandQueue& command) const;
         
+        void pushPlaceCommand(sf::Vector2i minSnappedGrid, CommandQueue& commands) const;
+
         int getTransformedId(int currentId, Transformation transform) const;
 
         void initialzeKeys();
 
     private:
         sf::RenderWindow& mWindow;
-        Referee mReferee;
+        Referee& mReferee;
 
         Team mTeam = Team::None; 
 
         TrayQuery* mTrayPtr;
         BoardQuery* mBoardPtr;
         PieceNode* mHeldPiecePtr; 
+
+        sf::Vector2i mCurrentMousePos;
 
         std::map<sf::Keyboard::Key, Transformation> mKeyBinding;
 };

--- a/include/client/Player.hpp
+++ b/include/client/Player.hpp
@@ -5,6 +5,8 @@
 #include "shared/Referee.hpp"
 #include "SFML/Window/Event.hpp"
 #include <map>
+#include <optional>
+
 
 namespace sf
 {

--- a/include/client/Utility.hpp
+++ b/include/client/Utility.hpp
@@ -1,0 +1,73 @@
+#ifndef UTILITY_HPP
+#define UTILITY_HPP
+
+#include "shared/Team.hpp"
+#include "Config.hpp"
+
+#include "SFML/Graphics/Color.hpp"
+#include "SFML/Graphics/Rect.hpp"
+
+namespace Utility
+{
+    inline sf::Color getShadowColor(Team team) 
+    {
+        sf::Color color;
+        switch (team) 
+        {   
+            case Team::None:
+            {
+                color = sf::Color(128, 128, 128);
+                break;
+            }
+            case Team::Red:
+            {
+                color = sf::Color(255, 75, 51);
+                break;
+            }
+            case Team::Blue:
+            {
+                color = sf::Color(46, 154, 255);
+                break;
+            }
+            case Team::Yellow:
+            {
+                color = sf::Color(255, 215, 0);
+                break;
+            }
+            case Team::Green:
+            {
+                color = sf::Color(73, 209, 27);
+                break;
+            }
+            default:
+            {
+                assert(false && "Invalid Team!");
+            }
+        }
+
+        color.a = 120; 
+        return color;
+    }
+
+    inline sf::IntRect getRect(Team team) 
+    {
+        int tileSize = static_cast<int>(Config::TileSize);
+        sf::Vector2i size = {tileSize, tileSize};
+
+        switch(team) 
+        {
+            case Team::Blue:   
+                return sf::IntRect({0, 0}, size);
+            case Team::Yellow: 
+                return sf::IntRect({tileSize, 0}, size);
+            case Team::Red:    
+                return sf::IntRect({0, tileSize}, size); 
+            case Team::Green:  
+                return sf::IntRect({tileSize, tileSize}, size);
+            default:           
+                return sf::IntRect({0, 0}, {0, 0});
+        }
+    }
+}
+
+#endif

--- a/include/client/Utility.hpp
+++ b/include/client/Utility.hpp
@@ -7,6 +7,9 @@
 #include "SFML/Graphics/Color.hpp"
 #include "SFML/Graphics/Rect.hpp"
 
+#include <cassert>
+
+
 namespace Utility
 {
     inline sf::Color getShadowColor(Team team) 
@@ -42,6 +45,7 @@ namespace Utility
             default:
             {
                 assert(false && "Invalid Team!");
+                break;
             }
         }
 

--- a/include/shared/Constants.hpp
+++ b/include/shared/Constants.hpp
@@ -10,6 +10,7 @@ namespace Blokus
 {
     inline constexpr int MaxBlocks = 5;
     inline constexpr int BoardSize = 12;
+    inline constexpr int CellCount = BoardSize * BoardSize; 
 
     inline constexpr std::array<sf::Vector2i, 4> CardinalOffsets = 
     {

--- a/include/shared/Referee.hpp
+++ b/include/shared/Referee.hpp
@@ -5,6 +5,8 @@
 #include "shared/Constants.hpp"
 #include "shared/PolyominoUtil.hpp"
 
+#include <vector>
+
 
 class Referee 
 {   

--- a/include/shared/Referee.hpp
+++ b/include/shared/Referee.hpp
@@ -11,7 +11,11 @@ class Referee
 public:
     Referee();
 
-    bool isValid(int pieceId, sf::Vector2i minOffset, Team team) const;
+    virtual ~Referee() = default;
+
+    virtual void place(int pieceId, sf::Vector2i minOffset, Team team);
+
+    virtual bool isValid(int pieceId, sf::Vector2i minOffset, Team team) const;
 
 private:
     bool canFit(const std::vector<sf::Vector2i>& blocks) const;
@@ -36,7 +40,7 @@ private:
     std::array<bool, TeamCount> mIsFirstMove;
     std::array<sf::Vector2i, TeamCount> mStartPos;
     std::array<int, TeamCount> mScores;
-    std::array<Team, Blokus::BoardSize * Blokus::BoardSize> mBoard;
+    std::array<Team, Blokus::CellCount> mBoard;
 };
 
 

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,17 +1,17 @@
 # Define library to be shared with tests
 add_library(BlokusClientLib STATIC
-Game.cpp
-StatisticsTracker.cpp
-Path.cpp
-Nodes/SceneNode.cpp
-Nodes/BlockNode.cpp
-Nodes/PieceNode.cpp
-Nodes/TrayNode.cpp
-Nodes/BoardNode.cpp
-Nodes/Arena.cpp
-Player.cpp 
 Command/Command.cpp
 Command/CommandQueue.cpp
+Nodes/Arena.cpp
+Nodes/BlockNode.cpp
+Nodes/BoardNode.cpp
+Nodes/PieceNode.cpp
+Nodes/SceneNode.cpp
+Nodes/TrayNode.cpp
+Game.cpp
+Path.cpp
+Player.cpp 
+StatisticsTracker.cpp
 )
 
 # Link dependencies

--- a/src/client/Game.cpp
+++ b/src/client/Game.cpp
@@ -22,8 +22,9 @@ Game::Game(FontHolder& fonts)
     , mTextures()
     , mFonts(fonts)
     , mStatistics()
+    , mReferee()
     , mArena(mWindow, mTextures, deck, mCommandQueue, Team::Red) 
-    , mPlayer(mWindow)
+    , mPlayer(mWindow, mReferee)
 {
     updateView(mWindow.getSize());
     loadTextures();
@@ -120,11 +121,11 @@ void Game::render()
 
 void Game::setQuery()
 {
-    assert(dynamic_cast<TrayQuery*>(mArena.getTrayNode()) != nullptr);
-    TrayQuery* trayPtr = static_cast<TrayQuery*>(mArena.getTrayNode());
+    assert(dynamic_cast<TrayQuery*>(mArena.getTrayNodePtr()) != nullptr);
+    TrayQuery* trayPtr = static_cast<TrayQuery*>(mArena.getTrayNodePtr());
 
-    assert(dynamic_cast<BoardQuery*>(mArena.getBoardNode()) != nullptr);
-    BoardQuery* boardPtr = static_cast<BoardQuery*>(mArena.getBoardNode());
+    assert(dynamic_cast<BoardQuery*>(mArena.getBoardNodePtr()) != nullptr);
+    BoardQuery* boardPtr = static_cast<BoardQuery*>(mArena.getBoardNodePtr());
 
     mPlayer.setQuery(trayPtr, boardPtr);
 }

--- a/src/client/Nodes/Arena.cpp
+++ b/src/client/Nodes/Arena.cpp
@@ -11,12 +11,14 @@
 #include <memory>
 
 
-Arena::Arena(sf::RenderTarget& target, TextureHolder& textures, std::array<int, Blokus::DeckSize> deck, CommandQueue& commands, Team team)
+Arena::Arena(sf::RenderTarget& target, TextureHolder& textures, 
+    std::array<int, Blokus::DeckSize> deck, 
+    CommandQueue& commands, Team team)
     : mTarget(target)
     , mTextures(textures)
     , mSceneLayers()
-    , mBoard(nullptr)
-    , mTray(nullptr)
+    , mBoardPtr(nullptr)
+    , mTrayPtr(nullptr)
     , mCommands(commands)
     , mActiveTeam(Team::Red)
     , mTeam(team)
@@ -35,16 +37,16 @@ void Arena::buildScene()
         SceneNode::attachChild(std::move(layer));
     }
 
-    auto board = std::make_unique<BoardNode>(mTextures);
-    mBoard = board.get();
+    auto board = std::make_unique<BoardNode>();
+    mBoardPtr = board.get();
     board->setPosition({ Config::Padding, Config::Padding });  
     mSceneLayers[World]->attachChild(std::move(board));
 
-    auto boardBounds = mBoard->getGlobalBounds();
+    auto boardBounds = mBoardPtr->getGlobalBounds();
 
     auto tray = std::make_unique<TrayNode>(mTextures);
-    mTray = tray.get();
-    mTray->setPosition({ 
+    mTrayPtr = tray.get();
+    mTrayPtr->setPosition({ 
         boardBounds.position.x + boardBounds.size.x + Config::Padding, // 10px gap
         boardBounds.position.y 
     });    
@@ -54,7 +56,7 @@ void Arena::buildScene()
     for (int slotId = 0; slotId < Blokus::DeckSize; ++slotId) {
         int pieceId = mDeck[slotId];
         auto piece = std::make_unique<PieceNode>(pieceId, mTeam, mTextures);
-        mTray->addPiece(slotId, std::move(piece));
+        mTrayPtr->addPiece(slotId, std::move(piece));
     }
 }
 
@@ -67,23 +69,39 @@ void Arena::grabPiece(int id, sf::Vector2f worldPos)
 {
     assert(id >= 0 && id < Blokus::PolyominoCount && "Invalid ID");
     //  Pull from Tray (The Tray identifies it by ID now, not position)
-    auto piece = mTray->withdrawPiece(id);
+    auto piece = mTrayPtr->withdrawPiece(id);
     
     // Transformation & Handoff
     piece->setOrigin(piece->getCentroid());
     piece->setPosition(worldPos); 
     
+    mActivePiecePtr = piece.get();
     mSceneLayers[Action]->attachChild(std::move(piece));
 }
 
-TrayNode* Arena::getTrayNode() const
+void Arena::placePiece(sf::Vector2i gridCoord)
 {
-    return mTray;
+    assert(mActivePiecePtr);
+    auto node = mSceneLayers[Action]->detachChild(*mActivePiecePtr); 
+    SceneNode* nodePtr = node.release();
+
+    assert(dynamic_cast<PieceNode*>(nodePtr));
+    std::unique_ptr<PieceNode> piece(static_cast<PieceNode*>(nodePtr));
+
+    piece->setOrigin({0, 0});
+    mBoardPtr->addPiece(std::move(piece), gridCoord);
+
+    mActivePiecePtr = nullptr;
 }
 
-BoardNode* Arena::getBoardNode() const
+TrayNode* Arena::getTrayNodePtr() const
 {
-    return mBoard;
+    return mTrayPtr;
+}
+
+BoardNode* Arena::getBoardNodePtr() const
+{
+    return mBoardPtr;
 }
 
 SceneNode* Arena::getLayer(Layer layer) const 

--- a/src/client/Nodes/BoardNode.cpp
+++ b/src/client/Nodes/BoardNode.cpp
@@ -1,10 +1,13 @@
 #include "Nodes/BoardNode.hpp"
+#include "Nodes/BlockNode.hpp"
+
 #include "SFML/Graphics/PrimitiveType.hpp"
 #include "SFML/Graphics/Vertex.hpp"
 #include "Config.hpp"
+#include <iostream>
 
 
-BoardNode::BoardNode(TextureHolder& textures)
+BoardNode::BoardNode()
     : mBoardLines(sf::PrimitiveType::Lines, (Blokus::BoardSize + 1) * 4)
 { // Should use private functions to organize code FirstMove, grid, background, score etc.
     float boardSize = Blokus::BoardSize * Config::GridSize;
@@ -58,15 +61,26 @@ void BoardNode::updateShadow(int pieceId, sf::Vector2i minSnappedGrid, sf::Color
     mShadow = { pieceId, minSnappedGrid, color };
 }
 
+void BoardNode::addPiece(std::unique_ptr<PieceNode> piece, sf::Vector2i gridPos) {
+    // 1. Calculate the local position relative to the BoardNode
+    sf::Vector2f localPos = { 
+        gridPos.x * Config::GridSize, 
+        gridPos.y * Config::GridSize 
+    };
+    
+    // 2. Set the position relative to THIS node (BoardNode)
+    piece->setPosition(localPos);
+    
+    // 3. Attach
+    attachChild(std::move(piece));
+}
 
 void BoardNode::drawCurrent(sf::RenderTarget& target, sf::RenderStates states) const
 {
-    // Draw background
     target.draw(mBackground, states);
 
-    // Draw grid lines
     target.draw(mBoardLines, states);
-
+     
     if (mShadow) 
     {
         drawShadow(target, states);

--- a/src/client/Nodes/BoardNode.cpp
+++ b/src/client/Nodes/BoardNode.cpp
@@ -4,7 +4,7 @@
 #include "SFML/Graphics/PrimitiveType.hpp"
 #include "SFML/Graphics/Vertex.hpp"
 #include "Config.hpp"
-#include <iostream>
+#include <cmath>
 
 
 BoardNode::BoardNode()
@@ -13,7 +13,7 @@ BoardNode::BoardNode()
     float boardSize = Blokus::BoardSize * Config::GridSize;
     
     // 1. Setup Background
-    mBackground.setSize({boardSize, boardSize});
+    mBackground.setSize({boardSize, boardSize});    
     mBackground.setFillColor(sf::Color::White); 
 
     sf::Color lineCol(100, 100, 100);

--- a/src/client/Nodes/PieceNode.cpp
+++ b/src/client/Nodes/PieceNode.cpp
@@ -1,31 +1,8 @@
 #include "Nodes/PieceNode.hpp"
 #include "Nodes/BlockNode.hpp"
-#include "Config.hpp"
-
-#include "SFML/Graphics/Rect.hpp"
 
 #include <memory>
-#include <iostream>
 
-
-sf::IntRect getRect(Team team) {
-    int tileSize = static_cast<int>(Config::TileSize);
-    sf::Vector2i size = {tileSize, tileSize};
-
-    switch(team) 
-    {
-        case Team::Blue:   
-            return sf::IntRect({0, 0}, size);
-        case Team::Yellow: 
-            return sf::IntRect({tileSize, 0}, size);
-        case Team::Red:    
-            return sf::IntRect({0, tileSize}, size); 
-        case Team::Green:  
-            return sf::IntRect({tileSize, tileSize}, size);
-        default:           
-            return sf::IntRect({0, 0}, {0, 0});
-    }
-}
 
 PieceNode::PieceNode(int pieceId, const Team team, TextureHolder& textures)
     : mCurrentId(pieceId)
@@ -67,7 +44,7 @@ void PieceNode::updateLayout()
     for (const auto& pos : coordinates) 
     {
         auto block = std::make_unique<BlockNode>(
-            mTextures.get(Textures::Tiles), getRect(mTeam));
+            mTextures.get(Textures::Tiles), Utility::getRect(mTeam));
         
         block->setPosition({pos.x * Config::GridSize, pos.y * Config::GridSize});
         attachChild(std::move(block));

--- a/src/client/Nodes/TrayNode.cpp
+++ b/src/client/Nodes/TrayNode.cpp
@@ -2,6 +2,8 @@
 
 #include <SFML/Graphics/RectangleShape.hpp>
 
+#include <algorithm>
+
 
 TrayNode::TrayNode(TextureHolder& textures)
     : mTextures(textures)

--- a/src/client/Player.cpp
+++ b/src/client/Player.cpp
@@ -16,7 +16,8 @@ Player::Player(sf::RenderWindow& window, Referee& referee)
     , mReferee(referee)
     , mTrayPtr(nullptr)
     , mBoardPtr(nullptr)
-    , mHeldPiecePtr(nullptr) 
+    , mHeldPiecePtr(nullptr)
+    , mCurrentMousePos(0, 0)
 {
     initialzeKeys();
 }

--- a/src/client/Player.cpp
+++ b/src/client/Player.cpp
@@ -211,6 +211,7 @@ int Player::getTransformedId(int currentId, Transformation transform) const
         default:
         {
             assert(false && "Invalid Transformation!");
+            return -1;
         }
     }
 }

--- a/src/client/Player.cpp
+++ b/src/client/Player.cpp
@@ -1,8 +1,6 @@
 #include "Player.hpp"
 
-#include "Config.hpp"
 #include "Command/CommandQueue.hpp"
-#include "Referee.hpp"
 #include "Nodes/Arena.hpp"
 #include "Nodes/PieceNode.hpp"
 #include "Nodes/BoardNode.hpp"
@@ -13,8 +11,9 @@
 #include <iostream>
 
 
-Player::Player(sf::RenderWindow& window)
+Player::Player(sf::RenderWindow& window, Referee& referee)
     : mWindow(window)
+    , mReferee(referee)
     , mTrayPtr(nullptr)
     , mBoardPtr(nullptr)
     , mHeldPiecePtr(nullptr) 
@@ -38,29 +37,39 @@ void Player::setTeam(Team team)
 
 void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
 {
-    if (auto mouseMoved = event.getIf<sf::Event::MouseMoved>())
-    {
-        if (mHeldPiecePtr)
-        {
-            sf::Vector2i mousePos = mouseMoved->position;
-            sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);
-            mHeldPiecePtr->setPosition(worldPos);
-        } 
-    }
-
     if (auto mousePressed = event.getIf<sf::Event::MouseButtonPressed>())
     {
-        if (mousePressed->button == sf::Mouse::Button::Left 
-            && !mHeldPiecePtr) 
+        if (mousePressed->button == sf::Mouse::Button::Left)
         {
             sf::Vector2i mousePos = mousePressed->position;
-            sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);            
-            if (auto piecePtr = mTrayPtr->getPieceAt(worldPos))
+            sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);   
+            
+            if (mHeldPiecePtr)
             {
-                mHeldPiecePtr = piecePtr; 
-                pushGrabCommand(worldPos, commands);
+                int pieceId = mHeldPiecePtr->getId();
+                sf::Vector2i minSnappedGrid = mBoardPtr->getMinSnappedGrid(worldPos, mHeldPiecePtr->getCentroid());
+                if (mReferee.isValid(pieceId, minSnappedGrid, mTeam))
+                {
+                    mReferee.place(pieceId, minSnappedGrid, mTeam);
+                    pushPlaceCommand(minSnappedGrid, commands);
+                    mHeldPiecePtr = nullptr; 
+                }
+                else 
+                {
+                    // pushReturnCommand()
+                }
+
+                //mHeldPiecePtr = nullptr;
             }
-        } 
+            else 
+            {          
+                if (auto piecePtr = mTrayPtr->getPieceAt(worldPos))
+                {
+                    mHeldPiecePtr = piecePtr; 
+                    pushGrabCommand(worldPos, commands);
+                }
+            } 
+        }
     }
 
     if (auto keyPressed = event.getIf<sf::Event::KeyPressed>()) 
@@ -74,9 +83,16 @@ void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
     }
 
     if (mHeldPiecePtr)
-    { // Check shadow 60 times every second
-        sf::Vector2i mousePos = sf::Mouse::getPosition(mWindow);
-        sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);
+    { 
+       if (auto mouseMoved = event.getIf<sf::Event::MouseMoved>())
+        {
+            mCurrentMousePos = mouseMoved->position;
+            sf::Vector2f worldPos = mWindow.mapPixelToCoords(mCurrentMousePos);
+            mHeldPiecePtr->setPosition(worldPos);
+        } 
+        
+        // Check shadow 60 times every second
+        sf::Vector2f worldPos = mWindow.mapPixelToCoords(mCurrentMousePos);
         
         pushShadowCommand(worldPos, commands);
     }
@@ -115,14 +131,30 @@ void Player::pushShadowCommand(sf::Vector2f worldPos, CommandQueue& commands) co
     sf::Vector2i minSnappedGrid = mBoardPtr->getMinSnappedGrid(worldPos, mHeldPiecePtr->getCentroid());
     
     int pieceId = mHeldPiecePtr->getId();
-    sf::Color color = Config::getShadowColor(mTeam);
+    sf::Color color = (mReferee.isValid(pieceId, minSnappedGrid, mTeam) ? 
+        Utility::getShadowColor(mTeam) : Utility::getShadowColor(Team::None));
 
-    Command shadow;
+    Command shadow; 
     shadow.category = Category::Board;
-    shadow.action = derivedAction<BoardNode>([pieceId, minSnappedGrid, color](BoardNode& board, sf::Time) {
+    shadow.action = derivedAction<BoardNode>(
+        [pieceId, minSnappedGrid, color](BoardNode& board, sf::Time) {
         board.updateShadow(pieceId, minSnappedGrid, color);
     });
+
     commands.push(shadow);    
+}
+
+void Player::pushPlaceCommand(sf::Vector2i minSnappedGrid, CommandQueue& commands) const 
+{
+    Command place;
+    place.category = Category::Arena;
+    place.action = derivedAction<Arena>(
+        [minSnappedGrid](Arena& arena, sf::Time) 
+    {
+        arena.placePiece(minSnappedGrid);
+    });
+
+    commands.push(place);
 }
 
 void Player::initialzeKeys()

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -6,8 +6,8 @@ set_source_files_properties("${GEN_HEADER}" PROPERTIES GENERATED TRUE)
 
 # Set SHARED_SOURCES that depend on GEN_HEADER
 set(SHARED_SOURCES
-    PolyominoUtil.cpp
     PolyominoLoader.cpp
+    PolyominoUtil.cpp
     Referee.cpp
 )
 

--- a/src/shared/Referee.cpp
+++ b/src/shared/Referee.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 
+
 Referee::Referee()
     : library(Blokus::PolyominoGenerator::getData())
 {
@@ -15,13 +16,24 @@ Referee::Referee()
         mStartPos[team] = { x, y };
     }
 
-    for (int x = 0; x < Blokus::BoardSize; ++x)
+    for (int cell = 0; cell < Blokus::CellCount; ++cell)
     {
-        for (int y = 0; y < Blokus::BoardSize; ++y)
-        {
-            mBoard[Blokus::getIndex(x, y)] = Team::None;
-        }
+        mBoard[cell] = Team::None;
     }
+}
+
+void Referee::place(int pieceId, sf::Vector2i minOffset, Team team)
+{
+    assert(isValid(pieceId, minOffset, team));
+
+    auto blocks = getBlockPositions(pieceId, minOffset);
+    for (const auto pos : blocks)
+    {
+        mBoard[Blokus::getIndex(pos.x, pos.y)] = team;
+    }
+
+    mIsFirstMove[team] = false;
+    mScores[team] += blocks.size();
 }
 
 bool Referee::isValid(int pieceId, sf::Vector2i minOffset, Team team) const
@@ -30,15 +42,18 @@ bool Referee::isValid(int pieceId, sf::Vector2i minOffset, Team team) const
     auto edges = getEdgePositions(pieceId, minOffset);
     auto corners = getCornerPositions(pieceId, minOffset);
 
-    if (!canFit(blocks) ||
-        (mIsFirstMove[team] && !isStartValid(blocks, team)) ||
-        (!mIsFirstMove[team] && !hasCornerContact(corners, team)) ||
-        hasEdgeContact(edges, team)) 
+    if (!canFit(blocks)) 
     {
         return false;
     }
-    
-    return true;
+    else if (mIsFirstMove[team]) 
+    {
+        return isStartValid(blocks, team);
+    }
+    else 
+    {
+        return hasCornerContact(corners, team) && !hasEdgeContact(edges, team);
+    }
 }
 
 bool Referee::canFit(const std::vector<sf::Vector2i>& blocks) const
@@ -89,6 +104,8 @@ bool Referee::hasCornerContact(const std::vector<sf::Vector2i>& corners, Team te
 
 bool Referee::hasEdgeContact(const std::vector<sf::Vector2i>& edges, Team team) const
 {
+    assert(!mIsFirstMove[team] && "Must not be first move!");
+
     for (const auto pos : edges) 
     {
         if (isWithinBound(pos) && 
@@ -103,8 +120,8 @@ bool Referee::hasEdgeContact(const std::vector<sf::Vector2i>& edges, Team team) 
 
 bool Referee::isWithinBound(const sf::Vector2i& pos) const
 {
-    return !(pos.x < 0 || pos.x >= Blokus::BoardSize || 
-        pos.y < 0 || pos.y >= Blokus::BoardSize);
+    return pos.x >= 0 && pos.x < Blokus::BoardSize && 
+        pos.y >= 0 && pos.y < Blokus::BoardSize;
 }
 
 std::vector<sf::Vector2i> Referee::getBlockPositions(int pieceId, sf::Vector2i minOffset) const
@@ -122,7 +139,7 @@ std::vector<sf::Vector2i> Referee::getBlockPositions(int pieceId, sf::Vector2i m
 std::vector<sf::Vector2i> Referee::getEdgePositions(int pieceId, sf::Vector2i minOffset) const
 {
     std::vector<sf::Vector2i> edgePositions;
-    const auto& edges = library.polyominoById.at(pieceId).sensors.edges;;
+    const auto& edges = library.polyominoById.at(pieceId).sensors.edges;
     for (auto pos : edges) 
     {
         edgePositions.push_back(minOffset + pos);
@@ -134,7 +151,7 @@ std::vector<sf::Vector2i> Referee::getEdgePositions(int pieceId, sf::Vector2i mi
 std::vector<sf::Vector2i> Referee::getCornerPositions(int pieceId, sf::Vector2i minOffset) const
 {
     std::vector<sf::Vector2i> cornerPositions;
-    const auto& corners = library.polyominoById.at(pieceId).sensors.corners;;
+    const auto& corners = library.polyominoById.at(pieceId).sensors.corners;
     for (auto pos : corners) 
     {
         cornerPositions.push_back(minOffset + pos);

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -12,10 +12,15 @@ add_executable(BlokusClientTests
     # add other test files here
 )
 
+target_compile_definitions(BlokusClientTests
+    PRIVATE
+        GTEST_LINKED_AS_SHARED_LIBRARY=1
+)
 
 target_link_libraries(BlokusClientTests
     PRIVATE
         BlokusClientLib
+        GTest::gmock      
         GTest::gmock_main        
         spdlog::spdlog
 )
@@ -26,6 +31,7 @@ target_include_directories(BlokusClientTests PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Mock # The Mock folder
 )
 
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 if(MSVC AND WIN32 AND BUILD_SHARED_LIBS)
     add_custom_command(TARGET BlokusClientTests POST_BUILD

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -12,10 +12,12 @@ add_executable(BlokusClientTests
     # add other test files here
 )
 
-target_compile_definitions(BlokusClientTests
-    PRIVATE
-        GTEST_LINKED_AS_SHARED_LIBRARY=1
-)
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(BlokusClientTests
+        PRIVATE
+            GTEST_LINKED_AS_SHARED_LIBRARY=1
+    )
+endif() 
 
 target_link_libraries(BlokusClientTests
     PRIVATE

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(BlokusClientTests
 target_link_libraries(BlokusClientTests
     PRIVATE
         BlokusClientLib
-        GTest::gtest_main
+        GTest::gmock_main        
         spdlog::spdlog
 )
 

--- a/tests/client/Mock/MockReferee.hpp
+++ b/tests/client/Mock/MockReferee.hpp
@@ -1,0 +1,14 @@
+#ifndef MOCK_REFEREE_HPP
+#define MOCK_REFEREE_HPP
+
+#include <gmock/gmock.h>
+#include "shared/Referee.hpp"
+
+class MockReferee : public Referee 
+{
+public:
+    // MOCK_METHOD(ReturnType, MethodName, (Args...), (Modifiers));
+    MOCK_METHOD(void, place, (int pieceId, sf::Vector2i minOffset, Team team), (override));
+    MOCK_METHOD(bool, isValid, (int pieceId, sf::Vector2i minOffset, Team team), (const, override));
+};
+#endif

--- a/tests/client/Mock/Nodes/MockArena.hpp
+++ b/tests/client/Mock/Nodes/MockArena.hpp
@@ -1,0 +1,24 @@
+#ifndef MOCK_ARENA_HPP
+#define MOCK_ARENA_HPP
+
+#include "Nodes/Arena.hpp"
+
+class MockArena : public Arena 
+{
+public:
+    // Inherit the constructor from Arena
+    using Arena::Arena; 
+
+    // Spy variables to track what the Command does
+    bool placePieceCalled = false;
+    sf::Vector2i lastPlacedGrid = {-1, -1};
+
+    // Override the function to intercept the call
+    void placePiece(sf::Vector2i gridCoord) override 
+    {
+        placePieceCalled = true;
+        lastPlacedGrid = gridCoord;
+    }
+};
+
+#endif

--- a/tests/client/Mock/Nodes/MockBoardNode.hpp
+++ b/tests/client/Mock/Nodes/MockBoardNode.hpp
@@ -8,9 +8,10 @@
 class MockBoardNode : public BoardNode 
 {
 public:
-    MockBoardNode(MockTextureHolder& textures)
-        : BoardNode(textures) 
-    {}
+    MockBoardNode()
+        : BoardNode() 
+    {
+    }
 
     void updateShadow(int pieceId, sf::Vector2i coord, sf::Color color) override 
     {
@@ -19,7 +20,7 @@ public:
         lastColor = color;
     }
 
-public:
+public: 
     int lastPieceId;
     sf::Vector2i lastCoord;
     sf::Color lastColor;

--- a/tests/client/Nodes/ArenaUnittest.cc
+++ b/tests/client/Nodes/ArenaUnittest.cc
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 #include "Nodes/Arena.hpp"
 #include "Nodes/PieceNode.hpp"
-#include "Nodes/TrayNode.hpp"
+#include "Nodes/TrayNode.hpp" 
+#include "Nodes/BoardNode.hpp"
+#include "shared/Referee.hpp"
 #include "Command/CommandQueue.hpp"
 #include "Mock/Resource/MockTextureHolder.hpp"
 
@@ -29,8 +31,8 @@ protected:
     const std::array<int, Blokus::DeckSize> deck = 
     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}; 
     CommandQueue commands;
-
     std::unique_ptr<Arena> arena; 
+
 };
 
 TEST_F(ArenaTest, GrabPiece) {
@@ -41,7 +43,7 @@ TEST_F(ArenaTest, GrabPiece) {
     sf::Vector2f targetPos(150.f, 200.f);
     
     // Ensure the piece exists in the tray first
-    auto* tray = arena->getTrayNode();
+    auto* tray = arena->getTrayNodePtr();
     auto* actionLayer = arena->getLayer(Arena::Action);
 
     // 2. Act
@@ -76,4 +78,35 @@ TEST_F(ArenaTest, GrabInvalidPiece) {
     ASSERT_DEATH({
         arena->grabPiece(fakeId, {0,0});
     }, "Invalid ID"); 
+}
+
+TEST_F(ArenaTest, PlacePiece) {
+    int targetId = 5;
+    arena->grabPiece(targetId, {150.f, 200.f}); 
+
+    auto* actionLayer = arena->getLayer(Arena::Action);
+    ASSERT_EQ(actionLayer->getChildCount(), 1);
+
+    sf::Vector2i targetGrid(3, 3);
+
+    arena->placePiece(targetGrid);
+    EXPECT_EQ(actionLayer->getChildCount(), 0);
+
+    auto* board = arena->getBoardNodePtr();
+    ASSERT_GT(board->getChildCount(), 0); 
+    
+    auto* placedPiece = static_cast<PieceNode*>(board->getChildren().back());
+    EXPECT_EQ(placedPiece->getId(), targetId);
+    EXPECT_EQ(placedPiece->getOrigin(), sf::Vector2f(0.f, 0.f)); 
+}
+
+TEST_F(ArenaTest, PlacePieceWithoutActivePiece) {
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    // We intentionally DO NOT call grabPiece() here. 
+    sf::Vector2i targetGrid(3, 3);
+
+    ASSERT_DEATH({
+        arena->placePiece(targetGrid);
+    }, ""); 
 }

--- a/tests/client/Nodes/BoardNodeUnittest.cc
+++ b/tests/client/Nodes/BoardNodeUnittest.cc
@@ -11,8 +11,8 @@ class BoardNodeTest : public ::testing::Test
 {
 protected:
     BoardNodeTest() 
-        : textures()           // Initialize textures first
-        , boardNode(textures)              // Default construct board
+        : textures()         
+        , boardNode()            
     {
     }
 

--- a/tests/client/Nodes/TrayNodeUnittest.cc
+++ b/tests/client/Nodes/TrayNodeUnittest.cc
@@ -52,8 +52,10 @@ TEST(TrayNodeTest, WithdrawalAndHitTest)
 
 TEST(TrayNodeTest, WithdrawInvalidIdCrashes) 
 {
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    
     MockTextureHolder testTextures;
     TrayNode tray(testTextures);
     // Requesting an ID that was never added
-    EXPECT_DEATH(tray.withdrawPiece(99), "Piece ID not found in Tray slots!");
+    ASSERT_DEATH(tray.withdrawPiece(99), "Piece ID not found in Tray slots!");
 }

--- a/tests/client/PlayerUnittest.cc
+++ b/tests/client/PlayerUnittest.cc
@@ -5,44 +5,47 @@
 #include "Mock/Query/MockTrayQuery.hpp"
 #include "Mock/Query/MockBoardQuery.hpp"
 #include "Mock/Nodes/MockBoardNode.hpp"
+#include "Mock/Nodes/MockArena.hpp"
+#include "Mock/MockReferee.hpp"
 #include "shared/PolyominoUtil.hpp"
-#include "Config.hpp"
+#include "Utility.hpp"
 
 
 class PlayerTest : public ::testing::Test {
 protected:
     PlayerTest() 
-        : mockTextures()           // Initialize textures first
-        , mockTray(mockTextures)   // Pass reference to mockTray
-        , mockBoard()              // Default construct board
-        , player(nullptr)          // Set to null until SetUp
+        : mTextures()           // Initialize textures first
+        , mTray(mTextures)   // Pass reference to mockTray
+        , mBoard()              // Default construct board
+        , mPlayer(nullptr)          // Set to null until SetUp
     {
     }
 
     void SetUp() override
     {
-        window.create(sf::VideoMode({800, 600}), "Test Window");
+        mWindow.create(sf::VideoMode({800, 600}), "Test Window");
         // RenderWindow can be initialized headlessly in SFML for most logic
         // MockTrayQuery is passed to the player (via a setter or constructor)
-        player = std::make_unique<Player>(window);
-        player->setQuery(&mockTray, &mockBoard);
+        mPlayer = std::make_unique<Player>(mWindow, mReferee);
+        mPlayer->setQuery(&mTray, &mBoard);
         
-        mockTextures.load(Textures::Tiles, "unused_path");
+        mTextures.load(Textures::Tiles, "unused_path");
     }
 
-    MockTextureHolder mockTextures;
-    sf::RenderWindow window;
-    MockTrayQuery mockTray;
-    MockBoardQuery mockBoard;
-    CommandQueue commands;
-    std::unique_ptr<Player> player;
+    MockTextureHolder mTextures;
+    sf::RenderWindow mWindow;
+    MockTrayQuery mTray;
+    MockBoardQuery mBoard;
+    CommandQueue mCommands;
+    std::unique_ptr<Player> mPlayer;
+    testing::NiceMock<MockReferee> mReferee;
 };
 
 
 TEST_F(PlayerTest, ValidGrab) {
     // 1. Arrange
     int responseId = 7;
-    mockTray.setPiece(responseId);
+    mTray.setPiece(responseId);
 
     // Create a fake MouseButtonPressed event
     sf::Event::MouseButtonPressed mousePressed;
@@ -50,19 +53,19 @@ TEST_F(PlayerTest, ValidGrab) {
     mousePressed.position = {100, 100};  
 
     // 2. Act
-    player->handleEvent(mousePressed, commands);
+    mPlayer->handleEvent(mousePressed, mCommands);
 
     // 3. Assert
-    EXPECT_FALSE(commands.isEmpty());
-    EXPECT_EQ(player->getHeldPieceId(), responseId);
+    EXPECT_FALSE(mCommands.isEmpty());
+    EXPECT_EQ(mPlayer->getHeldPieceId(), responseId);
 
     int size = 0;
-    while (!commands.isEmpty()) 
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Arena);
 
-        command = commands.pop(); 
+        command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
@@ -73,7 +76,7 @@ TEST_F(PlayerTest, ValidGrab) {
 TEST_F(PlayerTest, RightClickGrab) {
     // 1. Arrange
     int responseId = 7; 
-    mockTray.setPiece(responseId);
+    mTray.setPiece(responseId);
 
     // Create a fake MouseButtonPressed event
     sf::Event::MouseButtonPressed mousePressed;
@@ -81,90 +84,92 @@ TEST_F(PlayerTest, RightClickGrab) {
     mousePressed.position = {100, 100};
 
     // 2. Act
-    player->handleEvent(mousePressed, commands);
+    mPlayer->handleEvent(mousePressed, mCommands);
 
     // 3. Assert
-    EXPECT_TRUE(commands.isEmpty());
-    EXPECT_EQ(player->getHeldPieceId(), std::nullopt);
+    EXPECT_TRUE(mCommands.isEmpty());
+    EXPECT_EQ(mPlayer->getHeldPieceId(), std::nullopt);
 }
 
 TEST_F(PlayerTest, DoubleGrab) {
     // 1. Arrange: Player is already holding a piece
     int responseId = 7; 
-    mockTray.setPiece(responseId); 
+    mTray.setPiece(responseId); 
     
     sf::Event::MouseButtonPressed mousePressed;
     mousePressed.button = sf::Mouse::Button::Left;
     mousePressed.position = {100, 100};    
-
-    player->handleEvent(mousePressed, commands); // First click
-    EXPECT_FALSE(commands.isEmpty());
-    EXPECT_EQ(player->getHeldPieceId(), 7);
+         
+    mPlayer->handleEvent(mousePressed, mCommands); // First click
+    EXPECT_FALSE(mCommands.isEmpty());
+    EXPECT_EQ(mPlayer->getHeldPieceId(), 7);
     
     int size = 0;
-    while (!commands.isEmpty()) 
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Arena);
 
-        command = commands.pop(); 
+        command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
 
-    EXPECT_EQ(size, 1);
+    EXPECT_EQ(size, 1); 
 
+    ON_CALL(mReferee, isValid(responseId, testing::_, testing::_))
+    .WillByDefault(testing::Return(false));
     // 2. Act: Click again
     size = 0;
-    player->handleEvent(mousePressed, commands);
-    while (!commands.isEmpty()) 
+    mPlayer->handleEvent(mousePressed, mCommands);
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
     EXPECT_EQ(size, 1);
-    EXPECT_EQ(player->getHeldPieceId(), 7);
+    EXPECT_EQ(mPlayer->getHeldPieceId(), 7);
     
     // 3. Assert
     responseId = 8;
-    mockTray.setPiece(responseId);
+    mTray.setPiece(responseId);
 
     size = 0;
-    player->handleEvent(mousePressed, commands);
-    while (!commands.isEmpty()) 
+    mPlayer->handleEvent(mousePressed, mCommands);
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         ++size;
     } 
     EXPECT_EQ(size, 1);
-    EXPECT_EQ(player->getHeldPieceId(), 7);
+    EXPECT_EQ(mPlayer->getHeldPieceId(), 7);
 } 
 
 TEST_F(PlayerTest, Move) {
     sf::Event moveEvent = sf::Event::MouseMoved{{500, 600}};
 
-    player->handleEvent(moveEvent, commands);
-    EXPECT_TRUE(commands.isEmpty());
+    mPlayer->handleEvent(moveEvent, mCommands);
+    EXPECT_TRUE(mCommands.isEmpty());
 
     // Click piece 7
     int responseId = 7; 
-    mockTray.setPiece(responseId); 
+    mTray.setPiece(responseId); 
     
     sf::Event::MouseButtonPressed mousePressed;
     mousePressed.button = sf::Mouse::Button::Left;
     mousePressed.position = {100, 100}; 
 
-    player->handleEvent(mousePressed, commands);
+    mPlayer->handleEvent(mousePressed, mCommands);
     
     int size = 0;
-    while (!commands.isEmpty()) 
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Arena);
 
-        command = commands.pop(); 
+        command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         ++size;
     }
@@ -174,48 +179,54 @@ TEST_F(PlayerTest, Move) {
     Team color = Team::Red;
     sf::Vector2i grid = {300, 300};
 
-    player->setTeam(color);
-    mockBoard.setMinSnappedGrid(grid);
+    ON_CALL(mReferee, isValid(responseId, grid, color))
+    .WillByDefault(testing::Return(true));
+
+    mPlayer->setTeam(color);
+    mBoard.setMinSnappedGrid(grid);
     moveEvent = sf::Event::MouseMoved{{300, 300}};
-    player->handleEvent(moveEvent, commands);
+    mPlayer->handleEvent(moveEvent, mCommands);
 
     size = 0;
-    while (!commands.isEmpty()) 
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
 
-        MockBoardNode spyBoard(mockTextures);
+        MockBoardNode spyBoard;
         command.action(spyBoard, sf::Time::Zero);
 
         EXPECT_EQ(spyBoard.lastPieceId, responseId);
         EXPECT_EQ(spyBoard.lastCoord, grid);
-        EXPECT_EQ(spyBoard.lastColor, Config::getShadowColor(color));
+        EXPECT_EQ(spyBoard.lastColor, Utility::getShadowColor(color));
 
         ++size;
     }
     EXPECT_EQ(size, 1);
 
     color = Team::Blue;
-    grid = {400, 400};
+    grid = {400, 400};     
 
-    player->setTeam(color);
-    mockBoard.setMinSnappedGrid(grid);
+    ON_CALL(mReferee, isValid(responseId, grid, color))
+    .WillByDefault(testing::Return(true));
+
+    mPlayer->setTeam(color);
+    mBoard.setMinSnappedGrid(grid);
     moveEvent = sf::Event::MouseMoved{{300, 300}};
-    player->handleEvent(moveEvent, commands);
+    mPlayer->handleEvent(moveEvent, mCommands);
 
     size = 0;
-    while (!commands.isEmpty()) 
+    while (!mCommands.isEmpty()) 
     {
-        Command command = commands.pop(); 
+        Command command = mCommands.pop(); 
         EXPECT_EQ(command.category, Category::Board);
         
-        MockBoardNode spyBoard(mockTextures);
+        MockBoardNode spyBoard;
         command.action(spyBoard, sf::Time::Zero);
 
         EXPECT_EQ(spyBoard.lastPieceId, responseId);
         EXPECT_EQ(spyBoard.lastCoord, grid);
-        EXPECT_EQ(spyBoard.lastColor, Config::getShadowColor(color));
+        EXPECT_EQ(spyBoard.lastColor, Utility::getShadowColor(color));
 
         ++size;
     }
@@ -226,42 +237,93 @@ TEST_F(PlayerTest, Transform) {
     Blokus::PolyominoDefinition library = Blokus::PolyominoGenerator::getData();
 
     int initialId = 19; 
-    mockTray.setPiece(initialId);
+    mTray.setPiece(initialId);
     
     // Simulate a grab (Left click)
     sf::Event::MouseButtonPressed pressEvent;
     pressEvent.button = sf::Mouse::Button::Left;
     pressEvent.position = {100, 100};
-    player->handleEvent(pressEvent, commands);
+    mPlayer->handleEvent(pressEvent, mCommands);
 
     // Rotate CW
     sf::Event cwEvent = sf::Event::KeyPressed{sf::Keyboard::Key::R};
-    player->handleEvent(cwEvent, commands);
+    mPlayer->handleEvent(cwEvent, mCommands);
 
     int cwId = library.clockwiseRotatedIds[initialId];
-    ASSERT_TRUE(player->getHeldPieceId().has_value());
-    EXPECT_EQ(player->getHeldPieceId().value(), cwId); 
+    ASSERT_TRUE(mPlayer->getHeldPieceId().has_value());
+    EXPECT_EQ(mPlayer->getHeldPieceId().value(), cwId); 
 
     // Rotate CCW
     sf::Event ccwEvent = sf::Event::KeyPressed{sf::Keyboard::Key::C};
-    player->handleEvent(ccwEvent, commands);
+    mPlayer->handleEvent(ccwEvent, mCommands);
 
-    ASSERT_TRUE(player->getHeldPieceId().has_value());
-    EXPECT_EQ(player->getHeldPieceId().value(), initialId); 
+    ASSERT_TRUE(mPlayer->getHeldPieceId().has_value());
+    EXPECT_EQ(mPlayer->getHeldPieceId().value(), initialId); 
 
     // Horizontal Reflection
     int hId = library.horizontallyReflectedIds[initialId];
     sf::Event hEvent = sf::Event::KeyPressed{sf::Keyboard::Key::H};
-    player->handleEvent(hEvent, commands);
+    mPlayer->handleEvent(hEvent, mCommands);
 
-    ASSERT_TRUE(player->getHeldPieceId().has_value());
-    EXPECT_EQ(player->getHeldPieceId().value(), hId); 
+    ASSERT_TRUE(mPlayer->getHeldPieceId().has_value());
+    EXPECT_EQ(mPlayer->getHeldPieceId().value(), hId); 
 
     // Vertical Reflection
     int vId = library.clockwiseRotatedIds[cwId];
     sf::Event vEvent = sf::Event::KeyPressed{sf::Keyboard::Key::V};
-    player->handleEvent(vEvent, commands);
+    mPlayer->handleEvent(vEvent, mCommands);
 
-    ASSERT_TRUE(player->getHeldPieceId().has_value());
-    EXPECT_EQ(player->getHeldPieceId().value(), vId); 
+    ASSERT_TRUE(mPlayer->getHeldPieceId().has_value());
+    EXPECT_EQ(mPlayer->getHeldPieceId().value(), vId); 
+}
+
+TEST_F(PlayerTest, ValidPlacement) {
+    int pieceId = 7;
+    Team currentTeam = Team::Red;
+    sf::Vector2i expectedGrid = {300, 300};
+
+    mPlayer->setTeam(currentTeam);
+    mTray.setPiece(pieceId);
+    mBoard.setMinSnappedGrid(expectedGrid);
+
+    EXPECT_CALL(mReferee, isValid(pieceId, expectedGrid, currentTeam))
+        .WillRepeatedly(testing::Return(true));
+
+    EXPECT_CALL(mReferee, place(pieceId, expectedGrid, currentTeam))
+        .Times(1);
+
+    sf::Event::MouseButtonPressed grabClick;
+    grabClick.button = sf::Mouse::Button::Left;
+    grabClick.position = {100, 100};
+    mPlayer->handleEvent(grabClick, mCommands);
+
+    ASSERT_TRUE(mPlayer->getHeldPieceId().has_value());
+    while (!mCommands.isEmpty()) {
+        mCommands.pop();
+    }
+
+    sf::Event::MouseButtonPressed placeClick;
+    placeClick.button = sf::Mouse::Button::Left;
+    placeClick.position = {400, 400}; 
+    mPlayer->handleEvent(placeClick, mCommands);
+
+    EXPECT_FALSE(mPlayer->getHeldPieceId().has_value());
+
+    int size = 0;
+    while (!mCommands.isEmpty()) 
+    {
+        Command command = mCommands.pop(); 
+        
+        EXPECT_EQ(command.category, Category::Arena);
+        ++size;
+
+        MockArena spyArena(mWindow, mTextures, {}, mCommands, currentTeam);
+
+        command.action(spyArena, sf::Time::Zero);
+
+        EXPECT_TRUE(spyArena.placePieceCalled);
+        EXPECT_EQ(spyArena.lastPlacedGrid, expectedGrid);
+    }
+
+    EXPECT_EQ(size, 1);
 }

--- a/tests/client/Resource/ResourceHolderUnittest.cc
+++ b/tests/client/Resource/ResourceHolderUnittest.cc
@@ -87,8 +87,8 @@ namespace
 
     TEST(ResourceHolderDeathTest, AssertsOnMissingResource) 
     {
-        testing::FLAGS_gtest_death_test_style = "threadsafe";
-        
+        GTEST_FLAG_SET(death_test_style, "threadsafe");
+
         ResourceHolder<sf::Texture, ResourceID> textures;
         
         // We expect the program to 'die' when we call get() for a missing ID

--- a/tests/client/Resource/ResourceHolderUnittest.cc
+++ b/tests/client/Resource/ResourceHolderUnittest.cc
@@ -87,8 +87,8 @@ namespace
 
     TEST(ResourceHolderDeathTest, AssertsOnMissingResource) 
     {
-        GTEST_FLAG_SET(death_test_style, "threadsafe");
-
+        testing::FLAGS_gtest_death_test_style = "threadsafe";
+        
         ResourceHolder<sf::Texture, ResourceID> textures;
         
         // We expect the program to 'die' when we call get() for a missing ID

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(BlokusSharedTests
     PRIVATE
         BlokusSharedLib
         GTest::gtest_main
+        GTest::gmock      
         GTest::gmock_main
 )
 

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(BlokusSharedTests
 )
 
 if(MSVC AND WIN32 AND BUILD_SHARED_LIBS)
-    add_custom_command(TARget BlokusSharedTests POST_BUILD
+    add_custom_command(TARGET BlokusSharedTests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_RUNTIME_DLLS:BlokusSharedTests>
         $<TARGET_FILE_DIR:BlokusSharedTests>

--- a/tests/shared/RefereeUnittest.cc
+++ b/tests/shared/RefereeUnittest.cc
@@ -71,4 +71,73 @@ TEST(RefereeTest, Start) {
     EXPECT_FALSE(referee.isValid(1, {0, Blokus::BoardSize - 1}, Team::Green));
     EXPECT_TRUE(referee.isValid(1, {Blokus::BoardSize - 1, Blokus::BoardSize - 2}, Team::Green));
 }
+
+TEST(RefereeTest, ValidCornerContact) {
+    Referee referee;
+    
+    referee.place(0, {0, 0}, Team::Red);
+
+    EXPECT_TRUE(referee.isValid(0, {1, 1}, Team::Red));
+    
+    referee.place(0, {1, 1}, Team::Red);
+    EXPECT_TRUE(referee.isValid(0, {2, 2}, Team::Red));
+}
+
+TEST(RefereeTest, InvalidEdgeContact) {
+    Referee referee;
+    
+    referee.place(0, {0, 0}, Team::Red);
+
+    EXPECT_FALSE(referee.isValid(0, {1, 0}, Team::Red)); // Right edge
+    EXPECT_FALSE(referee.isValid(0, {0, 1}, Team::Red)); // Bottom edge
+    
+    referee.place(0, {1, 1}, Team::Red);
+    
+    EXPECT_FALSE(referee.isValid(0, {1, 0}, Team::Red)); 
+}
+
+TEST(RefereeTest, DisconnectedPlacement) {
+    Referee referee;
+    
+    referee.place(0, {0, 0}, Team::Red);
+
+    EXPECT_FALSE(referee.isValid(0, {2, 2}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {0, 5}, Team::Red));
+    EXPECT_FALSE(referee.isValid(0, {5, 5}, Team::Red));
+}
+
+TEST(RefereeTest, OverlapAndCollision) {
+    Referee referee;
+    
+    referee.place(0, {0, 0}, Team::Red);
+
+    EXPECT_FALSE(referee.isValid(0, {0, 0}, Team::Red));
+}
+
+TEST(RefereeTest, LargerPieceContact) {
+    Referee referee;
+    
+    referee.place(0, {0, 0}, Team::Red);
+
+    EXPECT_TRUE(referee.isValid(1, {1, 1}, Team::Red));
+    
+    // Placing pieces on the edge of the larger piece.
+    EXPECT_FALSE(referee.isValid(1, {1, 2}, Team::Red));
+    EXPECT_FALSE(referee.isValid(1, {2, 2}, Team::Red)); 
+}
+
+TEST(RefereeTest, OpponentInteraction) {
+    Referee referee;
+    
+    referee.place(0, {0, 0}, Team::Red);
+    referee.place(0, {Blokus::BoardSize - 1, 0}, Team::Blue);
+
+    // Vertical domino occupying {1,1} and {1,2}
+    referee.place(1, {1, 1}, Team::Red); 
+
+    EXPECT_TRUE(referee.isValid(0, {Blokus::BoardSize - 2, 1}, Team::Blue));
+
+    EXPECT_FALSE(referee.isValid(0, {2, 2}, Team::Blue)); // Touches Red's corner, but no Blue corner
+    EXPECT_FALSE(referee.isValid(0, {2, 0}, Team::Blue)); // Touches Red's edge, but no Blue corner
+}
  


### PR DESCRIPTION
## Progress
Closes #40 

## Description
- placePiece command to Arena
- mouse move position was updated
- renamed variables to TrayPtr, BoardPtr
- eliminated textures from BoardNode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immediate piece placement on click with live validity checks enforced by the referee.
  * Held-piece shadow now updates dynamically to indicate valid vs invalid placement.
  * Board accepts placed pieces into the scene at grid-aligned positions.

* **Refactor**
  * Internal scene and board management reorganized for clearer ownership and pointer-based access, improving robustness of grab/place interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->