### PR TITLE
Return Piece while clearing shadow

### DIFF
--- a/include/client/Nodes/Arena.hpp
+++ b/include/client/Nodes/Arena.hpp
@@ -41,6 +41,8 @@ public:
 
     virtual void placePiece(sf::Vector2i gridCoord);
 
+    virtual void returnPiece();
+
     TrayNode* getTrayNodePtr() const;
 
     BoardNode* getBoardNodePtr() const; 

--- a/include/client/Nodes/BoardNode.hpp
+++ b/include/client/Nodes/BoardNode.hpp
@@ -14,6 +14,8 @@
 
 class BoardNode : public SceneNode , public BoardQuery
 {
+    friend class BoardNodeTest; 
+
 public:
     BoardNode();
 
@@ -24,6 +26,8 @@ public:
     unsigned int getCategory() const override;
 
     virtual void updateShadow(int pieceId, sf::Vector2i minSnappedGrid, sf::Color color);
+
+    virtual void clearShadow();
 
     void addPiece(std::unique_ptr<PieceNode> piece, sf::Vector2i gridPos);
  

--- a/include/client/Player.hpp
+++ b/include/client/Player.hpp
@@ -50,8 +50,14 @@ class Player
         
         void pushPlaceCommand(sf::Vector2i minSnappedGrid, CommandQueue& commands) const;
 
-        int getTransformedId(int currentId, Transformation transform) const;
+        void pushReturnCommand(CommandQueue& commands) const;
 
+        void pushClearShadowCommand(CommandQueue& commands) const;
+
+        int getTransformedId(int currentId, Transformation transform) const;
+        
+        int getCanonicalId(int transformedId) const;
+        
         void initialzeKeys();
 
     private:

--- a/src/client/Nodes/Arena.cpp
+++ b/src/client/Nodes/Arena.cpp
@@ -94,6 +94,24 @@ void Arena::placePiece(sf::Vector2i gridCoord)
     mActivePiecePtr = nullptr;
 }
 
+void Arena::returnPiece()
+{
+    assert(mActivePiecePtr);
+    auto node = mSceneLayers[Action]->detachChild(*mActivePiecePtr); 
+    SceneNode* nodePtr = node.release();
+    
+    assert(dynamic_cast<SceneNode*>(nodePtr));
+    std::unique_ptr<PieceNode> piece(static_cast<PieceNode*>(nodePtr));
+
+    auto slotId = piece->getSlotId();
+    assert(slotId.has_value() && "Piece does not have a slot ID to return to!");
+
+    piece->setOrigin({0.f, 0.f});
+    mTrayPtr->addPiece(slotId.value(), std::move(piece));
+    
+    mActivePiecePtr = nullptr;
+}
+
 TrayNode* Arena::getTrayNodePtr() const
 {
     return mTrayPtr;

--- a/src/client/Nodes/BoardNode.cpp
+++ b/src/client/Nodes/BoardNode.cpp
@@ -61,6 +61,11 @@ void BoardNode::updateShadow(int pieceId, sf::Vector2i minSnappedGrid, sf::Color
     mShadow = { pieceId, minSnappedGrid, color };
 }
 
+void BoardNode::clearShadow()
+{
+    mShadow = std::nullopt;
+}
+
 void BoardNode::addPiece(std::unique_ptr<PieceNode> piece, sf::Vector2i gridPos) {
     // 1. Calculate the local position relative to the BoardNode
     sf::Vector2f localPos = { 

--- a/src/client/Player.cpp
+++ b/src/client/Player.cpp
@@ -42,8 +42,8 @@ void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
     {
         if (mousePressed->button == sf::Mouse::Button::Left)
         {
-            sf::Vector2i mousePos = mousePressed->position;
-            sf::Vector2f worldPos = mWindow.mapPixelToCoords(mousePos);   
+            mCurrentMousePos = mousePressed->position;            
+            sf::Vector2f worldPos = mWindow.mapPixelToCoords(mCurrentMousePos);   
             
             if (mHeldPiecePtr)
             {
@@ -53,14 +53,15 @@ void Player::handleEvent(const sf::Event& event, CommandQueue& commands)
                 {
                     mReferee.place(pieceId, minSnappedGrid, mTeam);
                     pushPlaceCommand(minSnappedGrid, commands);
-                    mHeldPiecePtr = nullptr; 
                 }
                 else 
                 {
-                    // pushReturnCommand()
+                    mHeldPiecePtr->setId(getCanonicalId(mHeldPiecePtr->getId()));
+                    pushReturnCommand(commands); 
                 }
-
-                //mHeldPiecePtr = nullptr;
+                
+                pushClearShadowCommand(commands);              
+                mHeldPiecePtr = nullptr;
             }
             else 
             {          
@@ -158,6 +159,32 @@ void Player::pushPlaceCommand(sf::Vector2i minSnappedGrid, CommandQueue& command
     commands.push(place);
 }
 
+void Player::pushReturnCommand(CommandQueue& commands) const
+{
+    Command returnCmd;
+    returnCmd.category = Category::Arena;
+    returnCmd.action = derivedAction<Arena>(
+        [](Arena& arena, sf::Time) 
+    {
+        arena.returnPiece();
+    });
+
+    commands.push(returnCmd);
+}
+
+void Player::pushClearShadowCommand(CommandQueue& commands) const
+{
+    Command clearShadow;
+    clearShadow.category = Category::Board;
+    clearShadow.action = derivedAction<BoardNode>(
+        [](BoardNode& board, sf::Time) {
+            // You will need to add a clearShadow() method to BoardNode
+            board.clearShadow(); 
+        });
+
+    commands.push(clearShadow);
+}
+
 void Player::initialzeKeys()
 {
     mKeyBinding[sf::Keyboard::Key::R] = RotateCW;
@@ -214,6 +241,14 @@ int Player::getTransformedId(int currentId, Transformation transform) const
             return -1;
         }
     }
+}
+
+int Player::getCanonicalId(int transformedId) const
+{
+    assert(transformedId >= 0 && transformedId < Blokus::PolyominoCount);
+    const auto& library = Blokus::PolyominoGenerator::getData();
+
+    return library.transformedToCanonical[transformedId];
 }
 
 

--- a/tests/client/Mock/Nodes/MockArena.hpp
+++ b/tests/client/Mock/Nodes/MockArena.hpp
@@ -2,22 +2,34 @@
 #define MOCK_ARENA_HPP
 
 #include "Nodes/Arena.hpp"
+#include <memory>
+
 
 class MockArena : public Arena 
 {
 public:
-    // Inherit the constructor from Arena
-    using Arena::Arena; 
+   MockArena(sf::RenderTarget& target, MockTextureHolder& textures, 
+              CommandQueue& commands, Team team)
+        : Arena(target, textures, 
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}, 
+            commands, team) 
+    {
+    }
 
     // Spy variables to track what the Command does
     bool placePieceCalled = false;
+    bool returnPieceCalled = false;
     sf::Vector2i lastPlacedGrid = {-1, -1};
 
-    // Override the function to intercept the call
     void placePiece(sf::Vector2i gridCoord) override 
     {
         placePieceCalled = true;
         lastPlacedGrid = gridCoord;
+    }
+
+    void returnPiece() override 
+    {
+        returnPieceCalled = true;
     }
 };
 

--- a/tests/client/Mock/Nodes/MockBoardNode.hpp
+++ b/tests/client/Mock/Nodes/MockBoardNode.hpp
@@ -10,20 +10,28 @@ class MockBoardNode : public BoardNode
 public:
     MockBoardNode()
         : BoardNode() 
+        , clearShadowCalled(false)
     {
     }
 
     void updateShadow(int pieceId, sf::Vector2i coord, sf::Color color) override 
     {
+        clearShadowCalled = false;
         lastPieceId = pieceId;
         lastCoord = coord;
         lastColor = color;
+    }
+
+    void clearShadow() override
+    {
+        clearShadowCalled = true;
     }
 
 public: 
     int lastPieceId;
     sf::Vector2i lastCoord;
     sf::Color lastColor;
+    bool clearShadowCalled;
 }; 
 
 #endif

--- a/tests/client/Nodes/ArenaUnittest.cc
+++ b/tests/client/Nodes/ArenaUnittest.cc
@@ -110,3 +110,31 @@ TEST_F(ArenaTest, PlacePieceWithoutActivePiece) {
         arena->placePiece(targetGrid);
     }, ""); 
 }
+
+TEST_F(ArenaTest, ReturnPiece_SuccessfullyReturnsToTray) {
+    int targetId = 1;
+    sf::Vector2f targetPos(150.f, 200.f);
+    arena->grabPiece(targetId, targetPos);
+
+    auto* actionLayer = arena->getLayer(Arena::Action);
+    ASSERT_EQ(actionLayer->getChildCount(), 1);
+
+    auto* grabbedPiece = static_cast<PieceNode*>(actionLayer->getChildren().back());
+    
+    arena->returnPiece();
+
+    EXPECT_EQ(actionLayer->getChildCount(), 0);
+
+    EXPECT_NO_FATAL_FAILURE({
+        arena->grabPiece(targetId, targetPos);
+    });
+}
+
+TEST_F(ArenaTest, ReturnPiece_WithoutActivePiece_Crashes) {
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    // Intentionally do NOT call grabPiece()
+    ASSERT_DEATH({
+        arena->returnPiece();
+    }, "");
+}

--- a/tests/client/Nodes/BoardNodeUnittest.cc
+++ b/tests/client/Nodes/BoardNodeUnittest.cc
@@ -10,20 +10,18 @@
 class BoardNodeTest : public ::testing::Test 
 {
 protected:
-    BoardNodeTest() 
-        : textures()         
-        , boardNode()            
+    void SetUp() override 
     {
+        boardNode = std::make_unique<BoardNode>();
+        boardNode->setPosition({100.f, 100.f});
+    }
+    
+    std::optional<BoardNode::Shadow> shadow() const 
+    {
+        return boardNode->mShadow;
     }
 
-    void SetUp() override {
-        // Assume Config::GridSize is 40.f for these calculations
-        // We set the board at an offset to test the InverseTransform
-        boardNode.setPosition({100.f, 100.f}); 
-    }
-
-    MockTextureHolder textures;
-    BoardNode boardNode;
+    std::unique_ptr<BoardNode> boardNode;
 };
 
 TEST_F(BoardNodeTest, GridSize)
@@ -40,7 +38,7 @@ TEST_F(BoardNodeTest, PerfectSnap)
     // localTopLeft = (20, 20) - (20, 20) = (0, 0).
     sf::Vector2f worldMouse(120.f, 120.f);
 
-    sf::Vector2i result = boardNode.getMinSnappedGrid(worldMouse, centroid);
+    sf::Vector2i result = boardNode->getMinSnappedGrid(worldMouse, centroid);
 
     EXPECT_EQ(result.x, 0);
     EXPECT_EQ(result.y, 0);
@@ -51,7 +49,7 @@ TEST_F(BoardNodeTest, RoundingUpThreshold)
     sf::Vector2f centroid(0.f, 0.f); 
     
     sf::Vector2f worldMouse(119.9f, 119.9f); 
-    sf::Vector2i result = boardNode.getMinSnappedGrid(worldMouse, centroid);
+    sf::Vector2i result = boardNode->getMinSnappedGrid(worldMouse, centroid);
     EXPECT_EQ(result.x, 0);
     EXPECT_EQ(result.y, 0);
 
@@ -61,13 +59,13 @@ TEST_F(BoardNodeTest, RoundingUpThreshold)
             static_cast<float> (pos) 
         };
 
-        result = boardNode.getMinSnappedGrid(worldMouse, centroid);
+        result = boardNode->getMinSnappedGrid(worldMouse, centroid);
         EXPECT_EQ(result.x, 1);
         EXPECT_EQ(result.y, 1); 
     }
 
     worldMouse = { 160.f, 160.f };
-    result = boardNode.getMinSnappedGrid(worldMouse, centroid);
+    result = boardNode->getMinSnappedGrid(worldMouse, centroid);
     EXPECT_EQ(result.x, 2);
     EXPECT_EQ(result.y, 2);
 }
@@ -77,7 +75,7 @@ TEST_F(BoardNodeTest, NegativeRounding)
     sf::Vector2f centroid(0.f, 0.f);
     
     sf::Vector2f worldMouse(80.f, 80.f); 
-    sf::Vector2i result = boardNode.getMinSnappedGrid(worldMouse, centroid);
+    sf::Vector2i result = boardNode->getMinSnappedGrid(worldMouse, centroid);
     EXPECT_EQ(result.x, -1);
     EXPECT_EQ(result.y, -1);
 
@@ -87,8 +85,30 @@ TEST_F(BoardNodeTest, NegativeRounding)
             static_cast<float> (pos) + 0.01f
         };
 
-        result = boardNode.getMinSnappedGrid(worldMouse, centroid);
+        result = boardNode->getMinSnappedGrid(worldMouse, centroid);
         EXPECT_EQ(result.x, 0);
         EXPECT_EQ(result.y, 0); 
     }
+}
+
+TEST_F(BoardNodeTest, UpdateAndClearShadow) {
+    // 1. Arrange
+    int pieceId = 3;
+    sf::Vector2i gridPos(5, 5);
+    sf::Color shadowColor = sf::Color(255, 255, 255, 128); // Test with alpha
+
+    // 2. Act (Update)
+    boardNode->updateShadow(pieceId, gridPos, shadowColor);
+
+    // 3. Assert (Update worked)
+    ASSERT_TRUE(shadow().has_value());
+    EXPECT_EQ(shadow()->pieceId, pieceId);
+    EXPECT_EQ(shadow()->minCoord, gridPos);
+    EXPECT_EQ(shadow()->color, shadowColor);
+
+    // 4. Act (Clear)
+    boardNode->clearShadow();
+
+    // 5. Assert (Clear worked)
+    EXPECT_FALSE(shadow().has_value());
 }

--- a/tests/client/PlayerUnittest.cc
+++ b/tests/client/PlayerUnittest.cc
@@ -27,6 +27,7 @@ protected:
         // RenderWindow can be initialized headlessly in SFML for most logic
         // MockTrayQuery is passed to the player (via a setter or constructor)
         mPlayer = std::make_unique<Player>(mWindow, mReferee);
+        mPlayer->setTeam(Team::Blue);
         mPlayer->setQuery(&mTray, &mBoard);
         
         mTextures.load(Textures::Tiles, "unused_path");
@@ -47,15 +48,12 @@ TEST_F(PlayerTest, ValidGrab) {
     int responseId = 7;
     mTray.setPiece(responseId);
 
-    // Create a fake MouseButtonPressed event
     sf::Event::MouseButtonPressed mousePressed;
     mousePressed.button = sf::Mouse::Button::Left;
     mousePressed.position = {100, 100};  
 
-    // 2. Act
     mPlayer->handleEvent(mousePressed, mCommands);
 
-    // 3. Assert
     EXPECT_FALSE(mCommands.isEmpty());
     EXPECT_EQ(mPlayer->getHeldPieceId(), responseId);
 
@@ -91,8 +89,7 @@ TEST_F(PlayerTest, RightClickGrab) {
     EXPECT_EQ(mPlayer->getHeldPieceId(), std::nullopt);
 }
 
-TEST_F(PlayerTest, DoubleGrab) {
-    // 1. Arrange: Player is already holding a piece
+TEST_F(PlayerTest, InvalidPlacement) {
     int responseId = 7; 
     mTray.setPiece(responseId); 
     
@@ -100,7 +97,8 @@ TEST_F(PlayerTest, DoubleGrab) {
     mousePressed.button = sf::Mouse::Button::Left;
     mousePressed.position = {100, 100};    
          
-    mPlayer->handleEvent(mousePressed, mCommands); // First click
+    // First Click
+    mPlayer->handleEvent(mousePressed, mCommands); 
     EXPECT_FALSE(mCommands.isEmpty());
     EXPECT_EQ(mPlayer->getHeldPieceId(), 7);
     
@@ -119,32 +117,47 @@ TEST_F(PlayerTest, DoubleGrab) {
 
     ON_CALL(mReferee, isValid(responseId, testing::_, testing::_))
     .WillByDefault(testing::Return(false));
-    // 2. Act: Click again
-    size = 0;
+    
+    int arenaCount = 0;
+    int boardCount = 0;
     mPlayer->handleEvent(mousePressed, mCommands);
     while (!mCommands.isEmpty()) 
     {
         Command command = mCommands.pop(); 
-        EXPECT_EQ(command.category, Category::Board);
-        ++size;
+        
+        if (command.category == Category::Arena) 
+        {
+            ++arenaCount;
+            MockArena spyArena(mWindow, mTextures, mCommands, mPlayer->getTeam());
+            EXPECT_FALSE(spyArena.returnPieceCalled);
+
+            command.action(spyArena, sf::Time::Zero);  
+
+            EXPECT_TRUE(spyArena.returnPieceCalled);
+        }
+        else if (command.category == Category::Board)
+        {
+            ++boardCount;
+
+            MockBoardNode spyBoard;
+            EXPECT_FALSE(spyBoard.clearShadowCalled);
+
+            command.action(spyBoard, sf::Time::Zero);
+            EXPECT_TRUE(spyBoard.clearShadowCalled);
+        } 
+
     }
-    EXPECT_EQ(size, 1);
-    EXPECT_EQ(mPlayer->getHeldPieceId(), 7);
+    EXPECT_EQ(arenaCount, 1);
+    EXPECT_EQ(boardCount, 1);
+    EXPECT_EQ(mPlayer->getHeldPieceId(), std::nullopt);
     
-    // 3. Assert
+    // 3. Grab again
     responseId = 8;
     mTray.setPiece(responseId);
 
-    size = 0;
+    arenaCount = 0;
     mPlayer->handleEvent(mousePressed, mCommands);
-    while (!mCommands.isEmpty()) 
-    {
-        Command command = mCommands.pop(); 
-        EXPECT_EQ(command.category, Category::Board);
-        ++size;
-    } 
-    EXPECT_EQ(size, 1);
-    EXPECT_EQ(mPlayer->getHeldPieceId(), 7);
+    EXPECT_EQ(mPlayer->getHeldPieceId(), 8);
 } 
 
 TEST_F(PlayerTest, Move) {
@@ -309,21 +322,35 @@ TEST_F(PlayerTest, ValidPlacement) {
 
     EXPECT_FALSE(mPlayer->getHeldPieceId().has_value());
 
-    int size = 0;
+    int arenaCount = 0;
+    int boardCount = 0;
     while (!mCommands.isEmpty()) 
     {
         Command command = mCommands.pop(); 
-        
-        EXPECT_EQ(command.category, Category::Arena);
-        ++size;
+       
+        if (command.category == Category::Arena) 
+        {
+            ++arenaCount;
+            MockArena spyArena(mWindow, mTextures, mCommands, currentTeam);
 
-        MockArena spyArena(mWindow, mTextures, {}, mCommands, currentTeam);
+            command.action(spyArena, sf::Time::Zero);
 
-        command.action(spyArena, sf::Time::Zero);
+            EXPECT_TRUE(spyArena.placePieceCalled);
+            EXPECT_EQ(spyArena.lastPlacedGrid, expectedGrid);
+        }
 
-        EXPECT_TRUE(spyArena.placePieceCalled);
-        EXPECT_EQ(spyArena.lastPlacedGrid, expectedGrid);
+        else if (command.category == Category::Board)
+        {
+            ++boardCount;
+
+            MockBoardNode spyBoard;
+            EXPECT_FALSE(spyBoard.clearShadowCalled);
+
+            command.action(spyBoard, sf::Time::Zero);
+            EXPECT_TRUE(spyBoard.clearShadowCalled);
+        }
     }
 
-    EXPECT_EQ(size, 1);
+    EXPECT_EQ(arenaCount, 1);
+    EXPECT_EQ(boardCount, 1);
 }


### PR DESCRIPTION
# Progress
- Closed #42 

# Description
- Returned PieceNode in Player following the cursor to TrayNode when a user clicks invalid location
- Cleared the shadow after placement or return
- Updated the currentMousePos after click to remove an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to return pieces to their original position during gameplay.
  * Added visual shadow clearing when placing pieces on the board.

* **Bug Fixes**
  * Improved handling of invalid piece placements with better cleanup and state management.

* **Tests**
  * Expanded test coverage for piece return and shadow clearing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->