### PR TITLE
Mocked Lobby and inline constexpr

### DIFF
--- a/include/client/ClientConfig.hpp
+++ b/include/client/ClientConfig.hpp
@@ -10,19 +10,19 @@
 
 namespace Config 
 {
-    const unsigned int ScreenWidth = 1920;
-    const unsigned int ScreenHeight = 1080;
+    inline constexpr unsigned int ScreenWidth = 1920;
+    inline constexpr unsigned int ScreenHeight = 1080;
     
-    const sf::Vector2f VirtualRes = { 
+    inline constexpr sf::Vector2f VirtualRes = { 
         static_cast<float>(ScreenWidth), 
         static_cast<float>(ScreenHeight) 
     };
 
     // --- Board Geometry (12x12) ---
-    const float GridSize = 40.f; 
-    const float TileSize = 512.f;
+    inline constexpr float GridSize = 40.f; 
+    inline constexpr float TileSize = 512.f;
 
-    const float Padding = 100.f;
+    inline constexpr float Padding = 100.f;
 }
 
 #endif

--- a/include/client/States/LobbyState.hpp
+++ b/include/client/States/LobbyState.hpp
@@ -1,0 +1,47 @@
+#ifndef LOBBY_STATE_HPP
+#define LOBBY_STATE_HPP
+
+#include "States/State.hpp"
+#include "shared/Game/GameSessionData.hpp"
+
+#include <SFML/Graphics/Text.hpp>
+#include <SFML/Graphics/Sprite.hpp>
+#include <SFML/Graphics/Texture.hpp>
+
+#include <map>
+
+
+class LobbyState : public State
+{
+public:
+	LobbyState(StateStack& stack, Context context);
+
+	virtual void draw();
+	virtual bool update(sf::Time dt);
+	virtual bool handleEvent(const sf::Event& event);
+
+protected:
+	// Inside LobbyState.hpp
+	struct LobbySlot {
+		int id;
+		sf::Text text;
+	};
+
+    void addPlayer(int id, const std::string& username);
+	void removePlayer(int id);
+
+	const sf::Text& getTitleText() const;
+	const sf::Text& getStatusText() const;
+	const std::vector<LobbySlot>& getUsernameTexts() const;
+
+	void recalculateLayout();
+	const sf::Vector2f getOffset(int pos) const;
+	
+private:
+	sf::Text mTitleText;
+    sf::Text mStatusText;
+  
+	std::vector<LobbySlot> mUsernameTexts;
+};
+
+#endif

--- a/include/client/States/StateIdentifiers.hpp
+++ b/include/client/States/StateIdentifiers.hpp
@@ -7,6 +7,7 @@ namespace States
 	{
 		None,
 		Title,
+		Lobby,
 		NetworkGame
 	};
 }

--- a/include/shared/Game/PlayerInfo.hpp
+++ b/include/shared/Game/PlayerInfo.hpp
@@ -2,7 +2,7 @@
 #define PLAYER_INFO_HPP
 
 #include "shared/Team.hpp"
-
+#include <cstdint>
 #include <string>
 
 
@@ -11,7 +11,6 @@ struct PlayerInfo
     int playerId;
     Team team;
     std::string username;
-    std::string profilePath; 
     bool isConnected;
     float remainingTime;    
 };

--- a/include/shared/SharedConfig.hpp
+++ b/include/shared/SharedConfig.hpp
@@ -23,9 +23,9 @@ namespace Config
         sf::Vector2i{1, -1}, sf::Vector2i{-1, -1}
     };
 
-    const int CanonicalCount = 21;
-    const int PolyominoCount = 91;
-    const int DeckSize = 18;
+    inline constexpr int CanonicalCount = 21;
+    inline constexpr int PolyominoCount = 91;
+    inline constexpr int DeckSize = 18;
 }
 
 #endif

--- a/src/client/Application.cpp
+++ b/src/client/Application.cpp
@@ -1,5 +1,6 @@
 #include "Application.hpp"
 #include "States/TitleState.hpp"
+#include "States/LobbyState.hpp"
 #include "States/NetworkGameState.hpp"
 #include "ClientConfig.hpp"
 #include "States/State.hpp"
@@ -134,5 +135,6 @@ void Application::render()
 void Application::registerStates()
 {
 	mStateStack.registerState<TitleState>(States::ID::Title);
+	mStateStack.registerState<LobbyState>(States::ID::Lobby);
 	mStateStack.registerState<NetworkGameState>(States::ID::NetworkGame);
 }

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -9,6 +9,7 @@ Nodes/BoardNode.cpp
 Nodes/PieceNode.cpp
 Nodes/SceneNode.cpp
 Nodes/TrayNode.cpp
+States/LobbyState.cpp
 States/NetworkGameState.cpp
 States/State.cpp
 States/StateStack.cpp

--- a/src/client/States/LobbyState.cpp
+++ b/src/client/States/LobbyState.cpp
@@ -1,0 +1,114 @@
+#include "States/LobbyState.hpp"
+#include "Resource/ResourceHolder.hpp"
+#include "ClientUtility.hpp" // Assuming you have centerOrigin here
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Window/Event.hpp>
+#include <algorithm>
+
+
+LobbyState::LobbyState(StateStack& stack, Context context)
+    : State(stack, context)
+    , mTitleText(context.fonts->get(Fonts::ID::Sansation), "LOBBY", 80)
+    , mStatusText(context.fonts->get(Fonts::ID::Sansation), "Waiting for players...", 30)
+{
+    centerOrigin(mTitleText);
+    centerOrigin(mStatusText);
+    
+    auto windowSize = context.window->getView().getSize();
+    mTitleText.setPosition({windowSize.x / 2.f, 150.f});
+    mStatusText.setPosition({windowSize.x / 2.f, 250.f});
+}
+
+bool LobbyState::update(sf::Time dt)
+{
+    return false; 
+}
+
+void LobbyState::addPlayer(int id, const std::string& username)
+{
+    GameSessionData& session = *getContext().gameSessionData;
+    session.playerById[id] = PlayerInfo{id, Team::Red, username, true, 0.f};
+    session.match.currentPlayerCount = session.playerById.size();
+
+    sf::Text userText(getContext().fonts->get(Fonts::ID::Sansation), username, 20);
+
+    mUsernameTexts.push_back({id, userText});
+    recalculateLayout();
+}
+
+void LobbyState::removePlayer(int id)
+{
+    GameSessionData& session = *getContext().gameSessionData;
+    session.playerById.erase(id);
+    session.match.currentPlayerCount = session.playerById.size();
+
+    mUsernameTexts.erase(
+        std::remove_if(mUsernameTexts.begin(), mUsernameTexts.end(),
+        [id](const LobbySlot& slot) {
+            return slot.id == id;
+        }), 
+        mUsernameTexts.end()
+    );
+
+    recalculateLayout();
+}
+
+void LobbyState::draw()
+{
+    sf::RenderWindow& window = *getContext().window;
+    
+    window.draw(mTitleText);
+    window.draw(mStatusText);
+
+    for (const auto& slot : mUsernameTexts) {
+        window.draw(slot.text);
+    }
+}
+
+bool LobbyState::handleEvent(const sf::Event& event)
+{
+    if (auto keyPressed = event.getIf<sf::Event::KeyReleased>()) 
+    {
+        if (keyPressed->code == sf::Keyboard::Key::Escape) 
+        {
+            getContext().networkClient->disconnect();
+
+            requestStackPop();
+            requestStackPush(States::ID::Title);
+        }
+        else if (keyPressed->code == sf::Keyboard::Key::Enter) 
+        {
+            requestStackPop();
+            requestStackPush(States::ID::NetworkGame);
+        }
+    }
+
+    return false;
+}
+
+const sf::Text& LobbyState::getTitleText() const
+{
+    return mTitleText;
+}
+
+const sf::Text& LobbyState::getStatusText() const
+{
+    return mStatusText;
+}
+
+const std::vector<LobbyState::LobbySlot>& LobbyState::getUsernameTexts() const
+{
+    return mUsernameTexts;
+}
+
+void LobbyState::recalculateLayout()
+{
+    for (size_t i = 0; i < mUsernameTexts.size(); ++i)
+    {
+        mUsernameTexts[i].text.setPosition(getOffset(i + 1));
+    }
+}
+const sf::Vector2f LobbyState::getOffset(int pos) const
+{
+    return {500.f, 250.f + (pos * 150.f)};
+}

--- a/src/client/States/TitleState.cpp
+++ b/src/client/States/TitleState.cpp
@@ -5,16 +5,16 @@
 
 TitleState::TitleState(StateStack& stack, Context context)
 	: State(stack, context)
-	, mTitleText(context.fonts->get(Fonts::ID::Sansation), "BLOKEM", 120)
+	, mTitleText(context.fonts->get(Fonts::ID::Sansation), "BLOKEM", 80)
 	, mText(context.fonts->get(Fonts::ID::Sansation), "Press any key to start", 30)
 	, mShowText(true)          
 	, mTextEffectTime(sf::Time::Zero)
 {
 	centerOrigin(mTitleText);
 	centerOrigin(mText);
-
+	
 	mText.setPosition(context.window->getView().getCenter());
-	mTitleText.setPosition({mText.getPosition().x, mText.getPosition().y / 2.f});
+	mTitleText.setPosition({mText.getPosition().x, 150.f});
 }
 
 void TitleState::draw()
@@ -47,7 +47,7 @@ bool TitleState::handleEvent(const sf::Event& event)
 	if (event.getIf<sf::Event::KeyReleased>())
 	{
 		requestStackPop();
-		requestStackPush(States::ID::NetworkGame);
+		requestStackPush(States::ID::Lobby);
 	}
 
 	return false;

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(BlokusClientTests
     Nodes/TrayNodeUnittest.cc
     Nodes/BoardNodeUnittest.cc     
     Resource/ResourceHolderUnittest.cc
+    States/LobbyStateUnittest.cc 
     States/NetworkGameStateUnittest.cc
     States/StateStackUnittest.cc
     States/TitleStateUnittest.cc

--- a/tests/client/States/LobbyStateUnittest.cc
+++ b/tests/client/States/LobbyStateUnittest.cc
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+#include "States/LobbyState.hpp"
+
+#include "Mock/Resource/MockTextureHolder.hpp"
+#include "Mock/Resource/MockFontHolder.hpp"
+
+#include "shared/TestBase.hpp"
+#include "States/TestableStateStack.hpp"
+
+#include <SFML/Graphics/RenderWindow.hpp>
+
+
+class TestableLobbyState : public LobbyState 
+{
+public:
+    using LobbyState::LobbyState;   
+
+    using LobbyState::addPlayer;
+    using LobbyState::removePlayer;
+
+    using LobbyState::getTitleText;
+    using LobbyState::getStatusText;
+    using LobbyState::getUsernameTexts;
+};
+
+class LobbyStateTest : public PolyominoTestBase 
+{
+protected:
+    sf::RenderWindow mWindow;
+    MockTextureHolder mTextureHolder; 
+    MockFontHolder mFontHolder;
+    GameSessionData mGameSessionData;
+    NetworkClient mNetworkClient;
+    
+    State::Context mContext;
+    TestableStateStack mStack;
+
+    LobbyStateTest()
+        : mContext(mWindow, mTextureHolder, mFontHolder, mGameSessionData, mNetworkClient, sLibrary)
+        , mStack(mContext)
+    {
+        mFontHolder.load(Fonts::ID::Sansation, "dummy/path.ttf");
+    }
+};
+
+TEST_F(LobbyStateTest, PlayerLayout) 
+{
+    TestableLobbyState state(mStack, mContext);
+
+    EXPECT_EQ(state.getTitleText().getString(), "LOBBY");
+    EXPECT_EQ(state.getStatusText().getString(), "Waiting for players...");
+
+    float yBegin = state.getStatusText().getPosition().y;
+
+    // Capture a LIVE REFERENCE to the vector to avoid copies.
+    const auto& slots = state.getUsernameTexts();
+    ASSERT_EQ(slots.size(), 0);
+
+    // Test Insertions
+    for (int i = 0; i < 3; ++i)
+    {
+        state.addPlayer(i, "user" + std::to_string(i));
+        
+        // 'slots' automatically updates because it is a reference!
+        const auto& slot = slots.back();
+
+        EXPECT_EQ(slot.id, i);
+        EXPECT_EQ(slot.text.getString(), "user" + std::to_string(i));
+        EXPECT_EQ(slot.text.getPosition().x, 500.f); // Verify X anchoring
+        EXPECT_EQ(slot.text.getPosition().y - yBegin, (i + 1) * 150.f);
+    } 
+
+    ASSERT_EQ(slots.size(), 3);
+
+    // Remove player from front
+    state.removePlayer(0);
+    ASSERT_EQ(slots.size(), 2);
+
+    for (int i = 0; i < slots.size(); ++i)
+    {
+        EXPECT_EQ(slots[i].id, i + 1);
+        EXPECT_EQ(slots[i].text.getString(), "user" + std::to_string(i + 1));
+        EXPECT_EQ(slots[i].text.getPosition().x, 500.f);
+        EXPECT_EQ(slots[i].text.getPosition().y - yBegin, (i + 1) * 150.f);
+    } 
+
+    // Remove all players from back
+    for (int i = 2; i > 0; --i)
+    {
+        state.removePlayer(i);
+        
+        for (int j = 0; j < slots.size(); ++j)
+        {
+            EXPECT_EQ(slots[j].id, j + 1);
+            EXPECT_EQ(slots[j].text.getString(), "user" + std::to_string(j + 1));
+            EXPECT_EQ(slots[j].text.getPosition().x, 500.f);
+            EXPECT_EQ(slots[j].text.getPosition().y - yBegin, (j + 1) * 150.f);
+        }
+    }
+    
+    EXPECT_EQ(slots.size(), 0);
+}

--- a/tests/client/States/TestableStateStack.hpp
+++ b/tests/client/States/TestableStateStack.hpp
@@ -1,0 +1,15 @@
+#ifndef TESTABLE_STATE_STACK_HPP
+#define TESTABLE_STATE_STACK_HPP
+
+#include "States/StateStack.hpp"
+
+
+class TestableStateStack : public StateStack 
+{
+public:
+    using StateStack::StateStack; 
+
+    using StateStack::getPendingChanges; 
+};
+
+#endif

--- a/tests/client/States/TitleStateUnittest.cc
+++ b/tests/client/States/TitleStateUnittest.cc
@@ -1,19 +1,14 @@
 #include <gtest/gtest.h>
 #include "States/TitleState.hpp"
-#include "States/StateStack.hpp"
+
 #include "Mock/Resource/MockTextureHolder.hpp"
 #include "Mock/Resource/MockFontHolder.hpp"
+
 #include "shared/TestBase.hpp"
+#include "States/TestableStateStack.hpp"
+
 #include <SFML/Graphics/RenderWindow.hpp>
 
-
-class TestableStateStack : public StateStack 
-{
-public:
-    using StateStack::StateStack; 
-
-    using StateStack::getPendingChanges; 
-};
 
 class TestableTitleState : public TitleState 
 {
@@ -74,29 +69,28 @@ TEST_F(TitleStateTest, StateTransition)
 {
     TestableTitleState state(mStack, mContext);
 
-    // Right click does not transition
-    sf::Event::MouseButtonPressed rightClick;
-    rightClick.button = sf::Mouse::Button::Right;
-    rightClick.position = {100, 100};
-
-    state.handleEvent(rightClick);
-
-    auto pendingChanges = mStack.getPendingChanges();
-
-    EXPECT_EQ(pendingChanges.size(), 0);
-
-    // Left click transitions
+    // Left click does not cause transition
     sf::Event::MouseButtonPressed leftClick;
     leftClick.button = sf::Mouse::Button::Left;
     leftClick.position = {100, 100};
 
     state.handleEvent(leftClick);
 
+    auto pendingChanges = mStack.getPendingChanges();
+
+    EXPECT_EQ(pendingChanges.size(), 0);
+
+    // Any Key causes transition 
+    sf::Event::KeyReleased spaceReleased;
+    spaceReleased.code = sf::Keyboard::Key::Space;
+
+    state.handleEvent(spaceReleased);
+
     pendingChanges = mStack.getPendingChanges();
 
-    ASSERT_EQ(pendingChanges.size(), 2);
-    EXPECT_EQ(pendingChanges[0].action, StateStack::Action::Pop);
+    EXPECT_EQ(pendingChanges.size(), 2);
+    EXPECT_EQ(pendingChanges[0].action, StateStack::Action::Pop);   
     EXPECT_EQ(pendingChanges[1].action, StateStack::Action::Push);
-    EXPECT_EQ(pendingChanges[1].stateID, States::ID::NetworkGame);
+    EXPECT_EQ(pendingChanges[1].stateID, States::ID::Lobby);
 }
 


### PR DESCRIPTION
## Progress
- Closed #55 

## Description
- Changed const to inline constexpr (const with external linkage)
- Added a LobbyState with mocked data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lobby screen with a dynamic player list and transitions from the title screen.
  * Title screen now navigates into the Lobby (press Space) and Lobby supports Enter (start) and Escape (return).

* **Refactor**
  * Simplified player info by removing an unused profile path field.
  * Adjusted title text size and positioning for improved UI presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyuhyunp-dev/Blokus/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->