### PR TITLE
TLS and Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore build output and binaries
+build/
+bin/
+cmake-build-*/
+
+# Ignore IDE and git configurations
+.vscode/
+.idea/
+.git/
+
+run_game.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ out
 .vscode
 .DS_Store
 assets/shared
+
+# Ignore generated TLS certificates and keys
+certs/*.key
+certs/*.crt
+certs/*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# 1. Start with a base Linux environment
+FROM ubuntu:24.04
+
+# 2. Install compilers, CMake, and SFML dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libfreetype6-dev \
+    libxrandr-dev \
+    libxcursor-dev \
+    libxi-dev \
+    libudev-dev \
+    libopengl-dev \
+    libflac-dev \
+    libvorbis-dev \
+    libgl1-mesa-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# 3. Copy your C++ source code into the container
+WORKDIR /app
+COPY . .
+
+# 4. Use CMake to build the BlokusServer executable
+RUN mkdir build && cd build && \
+    cmake .. && \
+    cmake --build .
+
+# 5. Tell the container to run the compiled game server on startup
+CMD ["./build/bin/BlokusServer"]

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,12 @@
+# Certificates Directory
+
+Local TLS certificates are generated dynamically for local development.
+
+To generate new self-signed certificates, run:
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout certs/server.key \
+  -out certs/server.crt \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  # Your C++ Game Server Container
+  game-server:
+    build: .                 # Tells Docker to run the Dockerfile above
+    expose:
+      - "8080"               # Opens port 8080 to Stunnel (but hides it from the internet)
+    networks:
+      - game-network
+
+  # The Stunnel Proxy Container
+  stunnel:
+    image: alpine:latest
+    command: >
+      sh -c "apk add --no-cache stunnel && stunnel /etc/stunnel/stunnel.conf"
+    ports:
+      - "443:443"
+    volumes:
+      - ./stunnel.conf:/etc/stunnel/stunnel.conf
+      - ./certs:/etc/stunnel/certs
+    networks:
+      - game-network
+    depends_on:
+      - game-server
+
+networks:
+  game-network:
+    driver: bridge

--- a/include/server/GameServer.hpp
+++ b/include/server/GameServer.hpp
@@ -23,7 +23,7 @@ namespace sf
 class GameServer 
 {
 public:
-    GameServer(unsigned short port = ServerPort);
+    GameServer(unsigned short port = 8080);
     void run();
 
 protected: // for run and unit test

--- a/src/client/Network/NetworkClient.cpp
+++ b/src/client/Network/NetworkClient.cpp
@@ -1,6 +1,7 @@
 #include "Network/NetworkClient.hpp"
 #include <SFML/Network/IpAddress.hpp>
 #include <spdlog/spdlog.h>
+#include <chrono>
 
 
 NetworkClient::NetworkClient()
@@ -24,7 +25,12 @@ bool NetworkClient::connect(std::string_view ip, unsigned short port)
     mSocket.setBlocking(true);
 
     // Attempt to connect with a 5-second timeout
+    auto start = std::chrono::steady_clock::now();
     sf::Socket::Status status = mSocket.connect(address.value(), port, sf::seconds(5.f));
+    auto end = std::chrono::steady_clock::now();
+
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    spdlog::info("Connection established in {} µs", duration.count());
 
     if (status == sf::Socket::Status::Done)
     {

--- a/src/client/States/TitleState.cpp
+++ b/src/client/States/TitleState.cpp
@@ -38,8 +38,11 @@ TitleState::TitleState(StateStack& stack, Context context)
 		mIsConnecting = true;
 		mConnectionFuture = std::async(std::launch::async, [this]()
 		{
+			sf::IpAddress serverIp = sf::IpAddress::LocalHost; // Or "127.0.0.1"
+			unsigned short serverPort = 443; // Stunnel's public TLS port
+
 			spdlog::info("[TitleState] Attempting to connect to server");
-			return getContext().networkClient->connect(IpAddress, ServerPort);
+			return getContext().networkClient->connect(serverIp.toString(), serverPort);
 		});
 
 		mStatusLabel->setText("Connecting...");

--- a/src/client/States/TitleState.cpp
+++ b/src/client/States/TitleState.cpp
@@ -39,7 +39,7 @@ TitleState::TitleState(StateStack& stack, Context context)
 		mConnectionFuture = std::async(std::launch::async, [this]()
 		{
 			sf::IpAddress serverIp = sf::IpAddress::LocalHost; // Or "127.0.0.1"
-			unsigned short serverPort = 443; // Stunnel's public TLS port
+			unsigned short serverPort = 8081; // Stunnel's public TLS port
 
 			spdlog::info("[TitleState] Attempting to connect to server");
 			return getContext().networkClient->connect(serverIp.toString(), serverPort);

--- a/stunnel-client.conf
+++ b/stunnel-client.conf
@@ -1,0 +1,6 @@
+client = yes
+foreground = yes
+
+[game-client-tls]
+accept = 127.0.0.1:8081
+connect = 127.0.0.1:443

--- a/stunnel.conf
+++ b/stunnel.conf
@@ -1,0 +1,16 @@
+# Run in foreground inside container
+foreground = yes
+
+[game-server-tls]
+# Accept encrypted TLS connections from the public internet
+accept = 0.0.0.0:443
+
+# Forward decrypted raw TCP to the game-server container
+connect = game-server:8080
+
+# TLS Certificate and Private Key (combined or separate)
+cert = /etc/stunnel/certs/server.crt
+key = /etc/stunnel/certs/server.key
+
+# Require modern TLS
+sslVersion = TLSv1.3

--- a/tests/server/GameServerUnittest.cc
+++ b/tests/server/GameServerUnittest.cc
@@ -385,3 +385,135 @@ TEST(GameServerTest, Security_PhantomConnectionHandling)
     server.processDisconnects();
     EXPECT_EQ(server.getClients().size(), 0) << "Server tracked a ghost connection.";
 }
+
+TEST(GameServerTest, Security_OversizedPacket) 
+{
+    TestableGameServer server;
+    sf::TcpSocket client;
+    ASSERT_EQ(client.connect(sf::IpAddress::LocalHost, server.getBoundPort()), sf::Socket::Status::Done);
+
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingConnections();
+
+    // Create a packet exceeding MAX_PACKET_BYTES (512 bytes)
+    sf::Packet oversizedPacket;
+    std::string largePayload(600, 'A');
+    oversizedPacket << largePayload;
+
+    ASSERT_EQ(client.send(oversizedPacket), sf::Socket::Status::Done);
+
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+
+    EXPECT_EQ(server.getClientsToDisconnect().size(), 1)
+        << "Server failed to flag client sending an oversized packet.";
+
+    server.processDisconnects();
+    EXPECT_EQ(server.getClients().size(), 0) << "Oversized packet sender was not disconnected.";
+}
+
+TEST(GameServerTest, Security_TrailingGarbageData) 
+{
+    TestableGameServer server;
+    sf::TcpSocket client;
+    ASSERT_EQ(client.connect(sf::IpAddress::LocalHost, server.getBoundPort()), sf::Socket::Status::Done);
+
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingConnections();
+
+    // Send CreateMatch appended with trailing unparsed garbage
+    sf::Packet garbagePacket;
+    garbagePacket << NetworkProtocol::PacketType::CreateMatch << std::string("unexpected_trailing_data");
+
+    ASSERT_EQ(client.send(garbagePacket), sf::Socket::Status::Done);
+
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+
+    // packet.endOfPacket() check should fail and flag client for disconnect
+    EXPECT_EQ(server.getClientsToDisconnect().size(), 1)
+        << "Server did not detect trailing garbage bytes in packet.";
+
+    server.processDisconnects();
+    EXPECT_EQ(server.getClients().size(), 0) << "Client with trailing garbage was not dropped.";
+}
+
+TEST(GameServerTest, Security_InvalidPacketTypeForState) 
+{
+    TestableGameServer server;
+    sf::TcpSocket client;
+    ASSERT_EQ(client.connect(sf::IpAddress::LocalHost, server.getBoundPort()), sf::Socket::Status::Done);
+
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingConnections();
+
+    // Send a packet type that is unhandled in TitleState (or out-of-range enum)
+    sf::Packet invalidTypePacket;
+    invalidTypePacket << static_cast<NetworkProtocol::PacketType>(9999);
+
+    ASSERT_EQ(client.send(invalidTypePacket), sf::Socket::Status::Done);
+
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+
+    // Default branch in handleTitleStatePackets should trigger disconnect
+    EXPECT_EQ(server.getClientsToDisconnect().size(), 1);
+
+    server.processDisconnects();
+    EXPECT_EQ(server.getClients().size(), 0) << "Invalid packet type did not disconnect client.";
+}
+
+TEST(GameServerTest, MatchCleanup_GuestLeavesFirst) 
+{
+    TestableGameServer server;
+
+    // Host connects and creates a match
+    sf::TcpSocket host;
+    ASSERT_EQ(host.connect(sf::IpAddress::LocalHost, server.getBoundPort()), sf::Socket::Status::Done);
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingConnections();
+
+    sf::Packet createReq;
+    createReq << NetworkProtocol::PacketType::CreateMatch;
+    ASSERT_EQ(host.send(createReq), sf::Socket::Status::Done);
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+
+    const std::string matchCode = server.getMatches().begin()->first;
+
+    // Guest connects and joins the match
+    sf::TcpSocket guest;
+    ASSERT_EQ(guest.connect(sf::IpAddress::LocalHost, server.getBoundPort()), sf::Socket::Status::Done);
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingConnections();
+
+    sf::Packet joinReq;
+    joinReq << NetworkProtocol::PacketType::JoinMatch << NetworkProtocol::JoinMatchRequest{ matchCode };
+    ASSERT_EQ(guest.send(joinReq), sf::Socket::Status::Done);
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+
+    const auto& matches = server.getMatches();
+    ASSERT_EQ(matches.at(matchCode).playerIDs.size(), 2);
+
+    // Guest disconnects first
+    guest.disconnect();
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+    server.processDisconnects();
+
+    // Verify match still exists with only 1 player remaining (Host)
+    EXPECT_EQ(server.getClients().size(), 1);
+    ASSERT_EQ(matches.count(matchCode), 1) << "Match was prematurely destroyed when guest left.";
+    EXPECT_EQ(matches.at(matchCode).playerIDs.size(), 1);
+
+    // Host disconnects last
+    host.disconnect();
+    ASSERT_TRUE(server.getSelector().wait(sf::milliseconds(50)));
+    server.handleIncomingPackets();
+    server.processDisconnects();
+
+    // Verify match is deleted when player count hits zero
+    EXPECT_EQ(server.getClients().size(), 0);
+    EXPECT_EQ(matches.size(), 0) << "Match was not cleaned up after the host left.";
+}

--- a/tests/server/GameServerUnittest.cc
+++ b/tests/server/GameServerUnittest.cc
@@ -9,7 +9,7 @@
 class TestableGameServer : public GameServer
 {
 public:
-    TestableGameServer(): GameServer(0) {}
+    TestableGameServer(): GameServer(sf::Socket::AnyPort) {}
 
     // Expose protected methods to public
     using GameServer::handleIncomingConnections;


### PR DESCRIPTION
## Description
- Using TLS to allow the server to securely send messages to its clients
### 7-Layer OSI Model (Abstract)
- `socket.connect()` initiates a Layer 4 (Transport) TCP 3-way handshake (SYN, SYN-ACK, ACK) with the target address.
- When using Stunnel, TLS operates at Layers 5 and 6 (Session and Presentation) to encrypt the stream.
- `socket.send()` takes Layer 7 (Application) payload data and hands it to the OS kernel to be wrapped in TCP segments for delivery.

### TLS 1.3 Steps
1. The server generates a Certificate Signing Request (CSR) with its domain name and public key, then sends it to a trusted third party called a Certificate Authority (CA)
2. The CA issues HTTP or DNS challenges to the server to verify ownership of the domain.
3. Once the challenges are completed, the CA creates a digital signature by hashing the server's certificate details (domain, public key, and an expiration date set by the CA) and encrypting that hash with the CA's private key.
4. The server receives this signed certificate and sends it to the client during the TLS handshake.
5. The client verifies the server by decrypting the CA's signature using the CA's public key (built into the OS or browser) and checking that it matches a freshly computed hash of the certificate payload.
6. Finally, the client and server execute an Elliptic-Curve Diffie-Hellman (ECDHE) key exchange to establish a shared symmetric session key without transmitting it over the wire.

### Why Docker
- Environment Reproducibility: Standardizes the Linux OS environment (Ubuntu 24.04), C++ toolchain, and build dependencies so my game server builds identically across macOS, Linux, or cloud servers.

- Network Isolation: Creates a private virtual network (game-network) that hides port 8080 from the host's public network interface, guaranteeing that outside traffic cannot bypass Stunnel.

- Service Orchestration: Manages multi-container lifecycles using docker compose—handling startup ordering, container links, and clean shutdowns.

### Why Stunnel
- TLS Termination: Acts as a reverse proxy that performs the cryptographic heavy lifting (TLS 1.3 handshakes, certificate management, and data decryption) at the perimeter.

- Protocol Decoupling: Allows my C++ BlokusServer application code to remain lightweight and encryption-agnostic—it simply receives plain, unencrypted TCP bytes on internal port 8080.


## Client Server Test
### Server side

#### Server start
`docker compose up --build`

#### Server output:
- On start
```
game-server-1  | [2026-08-21 22:50:27.666] [info] [GameServer] Server started. Listening on port 8080...

stunnel-1      | (1/1) Installing stunnel (5.76-r0)
stunnel-1      |   Executing stunnel-5.76-r0.pre-install
stunnel-1      |   Installing file to etc/stunnel/stunnel.conf.apk-new
stunnel-1      | Executing busybox-1.37.0-r31.trigger
stunnel-1      | OK: 8696 KiB in 17 packages
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: stunnel 5.76 on aarch64-alpine-linux-musl platform
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: Compiled with OpenSSL 3.5.6 7 Apr 2026
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: Running  with OpenSSL 3.5.7 9 Jun 2026
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: Reading configuration from file /etc/stunnel/stunnel.conf
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: UTF-8 byte order mark not detected
stunnel-1      | 2026.08.21 22:50:29 LOG5[ui]: Configuration successful
```

- Client Application Started
```
stunnel-1      | 2026.08.21 22:53:16 LOG5[0]: Service [game-server-tls] accepted connection from 192.168.65.1:55380
stunnel-1      | 2026.08.21 22:53:16 LOG5[0]: s_connect: connected 172.19.0.2:8080
stunnel-1      | 2026.08.21 22:53:16 LOG5[0]: Service [game-server-tls] connected remote server from 172.19.0.3:40104
game-server-1  | [2026-08-21 22:53:16.673] [info] [GameServer] New Client 0xaaaaf3813f90
game-server-1  | [2026-08-21 22:53:16.674] [info] [GameServer] New Client 0 connected from 172.19.0.3
```

- Client Application sent CreateMatch
```
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Handle Incoming Packet for Client 0
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Client 0 received packet
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Client 0 processing packet.
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Processing TitleState request for Client 0...
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Processing CreateMatch request for Client 0...
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Queued MatchJoined for Client 0 (Code: SEGN)
game-server-1  | [2026-08-21 22:54:19.833] [info] [GameServer] Socket is fully drained for Client 0
```

- Client application closed
```
game-server-1  | [2026-08-21 22:54:54.564] [info] [GameServer] Handle Incoming Packet for Client 0
game-server-1  | [2026-08-21 22:54:54.564] [info] [GameServer] Client 0 disconnected.
game-server-1  | [2026-08-21 22:54:54.564] [info] [GameServer] Removing client 0
stunnel-1      | 2026.08.21 22:54:54 LOG5[0]: Connection closed: 13 byte(s) sent to TLS, 5 byte(s) sent to socket
```

### Client side
#### Client Stunnel start
`stunnel stunnel-client.conf`

#### Client Stunnel output:

- On start
```
2026.08.21 15:51:33 LOG5[ui]: stunnel 5.80 on aarch64-apple-darwin25.6.0 platform
2026.08.21 15:51:33 LOG5[ui]: Compiled/running with OpenSSL 3.6.3 9 Jun 2026
2026.08.21 15:51:33 LOG5[ui]: Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI,DTLS
2026.08.21 15:51:33 LOG5[ui]: Reading configuration from file /Users/kyuhyunp/Project/Blokus/stunnel-client.conf
2026.08.21 15:51:33 LOG5[ui]: UTF-8 byte order mark not detected
2026.08.21 15:51:33 LOG5[ui]: FIPS provider disabled
2026.08.21 15:51:33 LOG4[ui]: Service [game-client-tls] needs authentication to prevent MITM attacks
2026.08.21 15:51:33 LOG5[ui]: Configuration successful
```

- Client application started
```
2026.08.21 15:53:16 LOG5[0]: Service [game-client-tls] accepted connection from 127.0.0.1:61249
2026.08.21 15:53:16 LOG5[0]: s_connect: connected 127.0.0.1:443
2026.08.21 15:53:16 LOG5[0]: Service [game-client-tls] connected remote server from 127.0.0.1:61250
```

- Client application closed
```
2026.08.21 15:54:54 LOG5[0]: Connection closed: 5 byte(s) sent to TLS, 13 byte(s) sent to socket
```


## Server side Testing using Server and Client terminals
#### Server start
`docker compose up --build`

#### Server output
```
game-server-1  | [2026-08-20 23:31:47.899] [info] [GameServer] Server started. Listening on port 8080...
```

#### Client input
`openssl s_client -connect localhost:443 -quiet`

#### Client output
```
Connecting to 127.0.0.1
Can't use SSL_get_servername
depth=0 CN=localhost
verify error:num=18:self-signed certificate
verify return:1
```

#### Server output
```
stunnel-1      | (1/1) Installing stunnel (5.76-r0)
stunnel-1      |   Executing stunnel-5.76-r0.pre-install
stunnel-1      |   Installing file to etc/stunnel/stunnel.conf.apk-new
stunnel-1      | Executing busybox-1.37.0-r31.trigger
stunnel-1      | OK: 8696 KiB in 17 packages
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: stunnel 5.76 on aarch64-alpine-linux-musl platform
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: Compiled with OpenSSL 3.5.6 7 Apr 2026
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: Running  with OpenSSL 3.5.7 9 Jun 2026
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,OCSP,PSK,SNI
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: Reading configuration from file /etc/stunnel/stunnel.conf
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: UTF-8 byte order mark not detected
stunnel-1      | 2026.08.20 23:31:48 LOG5[ui]: Configuration successful
stunnel-1      | 2026.08.20 23:33:33 LOG5[0]: Service [game-server-tls] accepted connection from 192.168.65.1:17823
stunnel-1      | 2026.08.20 23:33:33 LOG5[0]: s_connect: connected 172.19.0.2:8080
stunnel-1      | 2026.08.20 23:33:33 LOG5[0]: Service [game-server-tls] connected remote server from 172.19.0.3:53582
game-server-1  | [2026-08-20 23:33:33.418] [info] [GameServer] New Client 0xaaaae5159f90
game-server-1  | [2026-08-20 23:33:33.418] [info] [GameServer] New Client 0 connected from 172.19.0.3
```
#### Client input
`HELLO_SERVER`

#### Server output
```
game-server-1  | [2026-08-20 23:35:26.070] [info] [GameServer] Handle Incoming Packet for Client 0
game-server-1  | [2026-08-20 23:35:26.070] [info] [GameServer] Socket is fully drained for Client 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker-based deployment for the game server.
  * Added HTTPS support through a TLS proxy on port 443.
  * Added guidance for generating local TLS certificates.

* **Bug Fixes**
  * Updated the default game server port to 8080.
  * Improved title-screen connections by explicitly using localhost over port 443.
  * Updated server startup to use an automatically assigned available port when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->